### PR TITLE
Separate Note domain model from Room entity

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteDao.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteDao.kt
@@ -5,20 +5,19 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import com.oussamateyib.thoth.features.notes.domain.model.Note
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface NoteDao {
-    @Query("SELECT * FROM note")
-    fun getNotes(): Flow<List<Note>>
+    @Query("SELECT * FROM notes")
+    fun getNotes(): Flow<List<NoteEntity>>
 
-    @Query("SELECT * FROM note WHERE id = :id")
-    suspend fun getNoteById(id: Int): Note?
+    @Query("SELECT * FROM notes WHERE id = :id")
+    suspend fun getNoteById(id: Int): NoteEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertNote(note: Note)
+    suspend fun insertNote(note: NoteEntity)
 
     @Delete
-    suspend fun deleteNote(note: Note)
+    suspend fun deleteNote(note: NoteEntity)
 }

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteDatabase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteDatabase.kt
@@ -2,10 +2,9 @@ package com.oussamateyib.thoth.features.notes.data.local
 
 import androidx.room.RoomDatabase
 import androidx.room.Database
-import com.oussamateyib.thoth.features.notes.domain.model.Note
 
 @Database(
-    entities = [Note::class],
+    entities = [NoteEntity::class],
     version = 1
 )
 abstract class NoteDatabase : RoomDatabase() {

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteEntity.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteEntity.kt
@@ -1,0 +1,12 @@
+package com.oussamateyib.thoth.features.notes.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+@Entity(tableName = "notes")
+data class NoteEntity(
+    val title: String,
+    val content: String,
+    val timestamp: Long,
+    val color: Int,
+    @PrimaryKey val id: Int? = null
+)

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteEntity.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/local/NoteEntity.kt
@@ -2,6 +2,7 @@ package com.oussamateyib.thoth.features.notes.data.local
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+
 @Entity(tableName = "notes")
 data class NoteEntity(
     val title: String,

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/mappers/NoteMapper.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/mappers/NoteMapper.kt
@@ -1,0 +1,20 @@
+package com.oussamateyib.thoth.features.notes.data.mappers
+
+import com.oussamateyib.thoth.features.notes.data.local.NoteEntity
+import com.oussamateyib.thoth.features.notes.domain.model.Note
+
+fun NoteEntity.toDomain(): Note = Note(
+    title = title,
+    content = content,
+    timestamp = timestamp,
+    color = color,
+    id = id
+)
+
+fun Note.toEntity(): NoteEntity = NoteEntity(
+    title = title,
+    content = content,
+    timestamp = timestamp,
+    color = color,
+    id = id
+)

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/repository/NoteRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/repository/NoteRepositoryImpl.kt
@@ -1,26 +1,30 @@
 package com.oussamateyib.thoth.features.notes.data.repository
 
-import com.oussamateyib.thoth.features.notes.domain.model.Note
 import com.oussamateyib.thoth.features.notes.data.local.NoteDao
+import com.oussamateyib.thoth.features.notes.data.local.NoteEntity
+import com.oussamateyib.thoth.features.notes.data.mappers.toDomain
+import com.oussamateyib.thoth.features.notes.data.mappers.toEntity
+import com.oussamateyib.thoth.features.notes.domain.model.Note
 import com.oussamateyib.thoth.features.notes.domain.repository.NoteRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class NoteRepositoryImpl(
     private val dao: NoteDao
 ) : NoteRepository {
     override fun getNotes(): Flow<List<Note>> {
-        return dao.getNotes()
+        return dao.getNotes().map { it.map(NoteEntity::toDomain) }
     }
 
     override suspend fun getNoteById(id: Int): Note? {
-        return dao.getNoteById(id)
+        return dao.getNoteById(id)?.toDomain()
     }
 
     override suspend fun insertNote(note: Note) {
-        return dao.insertNote(note)
+        dao.insertNote(note.toEntity())
     }
 
     override suspend fun deleteNote(note: Note) {
-        return dao.deleteNote(note)
+        dao.deleteNote(note.toEntity())
     }
 }

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/model/Note.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/model/Note.kt
@@ -1,18 +1,9 @@
 package com.oussamateyib.thoth.features.notes.domain.model
 
-import androidx.room.Entity
-import androidx.room.PrimaryKey
-import com.oussamateyib.thoth.ui.theme.*
-
-@Entity
 data class Note(
     val title: String,
     val content: String,
     val timestamp: Long,
     val color: Int,
-    @PrimaryKey val id: Int? = null
-) {
-    companion object {
-        val noteColors = listOf(RedPink, RedOrange, LightGreen, Violet, BabyBlue)
-    }
-}
+    val id: Int? = null
+)

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/utils/NoteColors.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/utils/NoteColors.kt
@@ -1,0 +1,11 @@
+package com.oussamateyib.thoth.features.notes.presentation.utils
+
+import com.oussamateyib.thoth.ui.theme.BabyBlue
+import com.oussamateyib.thoth.ui.theme.LightGreen
+import com.oussamateyib.thoth.ui.theme.RedOrange
+import com.oussamateyib.thoth.ui.theme.RedPink
+import com.oussamateyib.thoth.ui.theme.Violet
+
+class NoteColors {
+    val noteColors = listOf(RedPink, RedOrange, LightGreen, Violet, BabyBlue)
+}


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description
Decouples the `Note` domain model from the Room persistence layer by introducing a dedicated `NoteEntity` for the database, a `NoteMapper` for conversions between the two, and a `NoteColors` utility class to house the color constants previously embedded in the domain model.

### Changes
- Adds `NoteEntity` data class in the `data/local` layer.
- Removes Room annotations and color constants from the `Note` domain model.
- Adds `NoteMapper` with `toDomain()` and `toEntity()` extension functions for mapping between `NoteEntity` and `Note`.
- Updates `NoteDao` to operate on `NoteEntity` instead of `Note`..
- Updates `NoteDatabase` to register `NoteEntity` instead of `Note`.
- Updates `NoteRepositoryImpl` to apply mappers when reading from and writing to the DAO.
- Extractes color constants into a new `NoteColors` utility class under `presentation/utils`.

### Issues
- Closes #5 
