### PR TITLE
Create split APKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,10 @@ jobs:
           set -euo pipefail
           RELEASE_VERSION="${GITHUB_REF_NAME}"
 
-          # Move and rename APK:
-          mv app/build/outputs/apk/release/app-release.apk "Thoth_${RELEASE_VERSION}.apk"
+          # Move and rename APKs
+          for apk in app/build/outputs/apk/release/*.apk; do
+            mv "$apk" "Thoth_${RELEASE_VERSION}_$(basename "$apk" | sed -E 's/app-(.*)-release\.apk/\1/').apk"
+          done
 
           # Move and rename AAB
           mv app/build/outputs/bundle/release/app-release.aab "Thoth_${RELEASE_VERSION}.aab"
@@ -49,7 +51,7 @@ jobs:
 
           # Generate SHA256SUMS
           sha256sum \
-            Thoth_${RELEASE_VERSION}.apk \
+            Thoth_${RELEASE_VERSION}_*.apk \
             Thoth_${RELEASE_VERSION}.aab \
             mapping.txt \
             > SHA256SUMS
@@ -65,7 +67,7 @@ jobs:
           generate_release_notes: true
           discussion_category_name: Announcements
           files: |
-            Thoth_${{ github.ref_name }}.apk
+            Thoth_${{ github.ref_name }}_*.apk
             Thoth_${{ github.ref_name }}.aab
             mapping.txt
             SHA256SUMS

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+// Detect if the current build is for an Android App Bundle (AAB)
+val isBuildingBundle = gradle.startParameter.taskNames.any { it.lowercase().contains("bundle") }
+
 android {
     // Application configuration
     namespace = "com.oussamateyib.thoth"
@@ -23,6 +26,20 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    // ABI splits configuration
+    splits {
+        abi {
+            // Disable ABI splits when building an App Bundle to avoid conflicts
+            isEnable = !isBuildingBundle
+            // Reset previous ABI split configuration
+            reset()
+            // Specify the supported ABIs
+            include("x86", "x86_64", "armeabi-v7a", "arm64-v8a", "riscv64")
+            // Generate a universal APK when ABI splits are enabled
+            isUniversalApk = true
+        }
     }
 
     // Signing configuration

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
             // Reset previous ABI split configuration
             reset()
             // Specify the supported ABIs
-            include("x86", "x86_64", "armeabi-v7a", "arm64-v8a", "riscv64")
+            include("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
             // Generate a universal APK when ABI splits are enabled
             isUniversalApk = true
         }


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description
Enables generation of ABI-specific APKs, as Jetpack Compose bundles native libraries into the final APK, which can increase its size.

### Changes
- Adds configuration for split APK generation per ABI.
- Updates the release workflow to accommodate the new split APK artifacts .