### PR TITLE
Add use cases

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/DeleteNoteUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/DeleteNoteUseCase.kt
@@ -1,0 +1,12 @@
+package com.oussamateyib.thoth.features.notes.domain.usecase
+
+import com.oussamateyib.thoth.features.notes.domain.model.Note
+import com.oussamateyib.thoth.features.notes.domain.repository.NoteRepository
+
+class DeleteNoteUseCase(
+    val repository: NoteRepository
+) {
+    suspend operator fun invoke(note : Note) {
+        repository.deleteNote(note)
+    }
+}

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/GetNoteByIdUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/GetNoteByIdUseCase.kt
@@ -1,0 +1,12 @@
+package com.oussamateyib.thoth.features.notes.domain.usecase
+
+import com.oussamateyib.thoth.features.notes.domain.model.Note
+import com.oussamateyib.thoth.features.notes.domain.repository.NoteRepository
+
+class GetNoteByIdUseCase(
+    val repository: NoteRepository
+) {
+    suspend operator fun invoke(id : Int) : Note? {
+        return repository.getNoteById(id)
+    }
+}

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/GetNotesUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/GetNotesUseCase.kt
@@ -1,0 +1,35 @@
+package com.oussamateyib.thoth.features.notes.domain.usecase
+
+import com.oussamateyib.thoth.features.notes.domain.model.Note
+import com.oussamateyib.thoth.features.notes.domain.repository.NoteRepository
+import com.oussamateyib.thoth.features.notes.domain.util.NoteOrder
+import com.oussamateyib.thoth.features.notes.domain.util.OrderType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class GetNotesUseCase(
+    private val repository: NoteRepository
+) {
+    operator fun invoke(
+        noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending)
+    ): Flow<List<Note>> {
+        return repository.getNotes().map { notes ->
+            when (noteOrder) {
+                is NoteOrder.Title -> when (noteOrder.orderType) {
+                    is OrderType.Ascending -> notes.sortedBy { it.title.lowercase() }
+                    is OrderType.Descending -> notes.sortedByDescending { it.title.lowercase() }
+                }
+
+                is NoteOrder.Date -> when (noteOrder.orderType) {
+                    is OrderType.Ascending -> notes.sortedBy { it.timestamp }
+                    is OrderType.Descending -> notes.sortedByDescending { it.timestamp }
+                }
+
+                is NoteOrder.Color -> when (noteOrder.orderType) {
+                    is OrderType.Ascending -> notes.sortedBy { it.color }
+                    is OrderType.Descending -> notes.sortedByDescending { it.color }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/InsertNoteUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/InsertNoteUseCase.kt
@@ -1,0 +1,12 @@
+package com.oussamateyib.thoth.features.notes.domain.usecase
+
+import com.oussamateyib.thoth.features.notes.domain.model.Note
+import com.oussamateyib.thoth.features.notes.domain.repository.NoteRepository
+
+class InsertNoteUseCase(
+    val repository: NoteRepository
+) {
+    suspend operator fun invoke(note : Note) {
+        repository.insertNote(note)
+    }
+}

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/util/NoteOrder.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/util/NoteOrder.kt
@@ -1,0 +1,9 @@
+package com.oussamateyib.thoth.features.notes.domain.util
+
+sealed class NoteOrder(
+    val orderType: OrderType
+) {
+    class Title(orderType: OrderType) : NoteOrder(orderType)
+    class Date(orderType: OrderType) : NoteOrder(orderType)
+    class Color(orderType: OrderType) : NoteOrder(orderType)
+}

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/util/OrderType.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/util/OrderType.kt
@@ -1,0 +1,6 @@
+package com.oussamateyib.thoth.features.notes.domain.util
+
+sealed class OrderType {
+    object Ascending : OrderType()
+    object Descending : OrderType()
+}


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description
This pull request introduces the domain use case layer for the notes feature, along with ordering utilities. Each use case wraps the `NoteRepository` and exposes a single invoke operator, keeping the domain logic clean and testable in isolation from other layers.

### Changes
- Added` DeleteNoteUseCase`, `GetNoteByIdUseCase`, `InsertNoteUseCase`, and `GetNotesUseCase` — each delegating to `NoteRepository` via a suspending or `Flow`-based invoke operator.
- `GetNotesUseCase` supports sorting notes by title, date, or color in ascending or descending order, applied reactively on the repository's `Flow`.
- Added `NoteOrder` sealed class (`Title`, `Date`, `Color`) and `OrderType` sealed class (`Ascending`, `Descending`) to model sort options cleanly.
