### PR TITLE
Migrate `NoteListViewModel` state from `mutableStateOf` to `MutableStateFlow`

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -37,6 +38,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.oussamateyib.thoth.R
 import com.oussamateyib.thoth.features.notes.presentation.list.components.NoteItem
@@ -48,7 +50,7 @@ import kotlinx.coroutines.launch
 fun NoteListScreen(
     navController: NavController, viewModel: NoteListViewModel = hiltViewModel()
 ) {
-    val state = viewModel.state.value
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -101,7 +103,7 @@ fun NoteListScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding )
+                .padding(innerPadding)
                 .padding(horizontal = 16.dp)
         ) {
             AnimatedVisibility(

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListViewModel.kt
@@ -1,7 +1,5 @@
 package com.oussamateyib.thoth.features.notes.presentation.list
 
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oussamateyib.thoth.features.notes.domain.model.Note
@@ -12,6 +10,10 @@ import com.oussamateyib.thoth.features.notes.domain.util.NoteOrder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -20,8 +22,8 @@ class NoteListViewModel @Inject constructor(
     private val getNotesUseCase: GetNotesUseCase,
     private val insertNoteUseCase: InsertNoteUseCase
 ) : ViewModel() {
-    private val _state = mutableStateOf(NoteListState())
-    val state: State<NoteListState> = _state
+    private val _state = MutableStateFlow(NoteListState())
+    val state: StateFlow<NoteListState> = _state.asStateFlow()
 
     // Holds the active collection job so it can be canceled on re-fetch
     private var getNotesJob: Job? = null
@@ -39,17 +41,17 @@ class NoteListViewModel @Inject constructor(
                 if (state.value.noteOrder::class == event.noteOrder::class &&
                     state.value.noteOrder.orderType == event.noteOrder.orderType
                 ) return
-                _state.value = state.value.copy(
-                    noteOrder = event.noteOrder
-                )
+                _state.update {
+                    it.copy(noteOrder = event.noteOrder)
+                }
                 // Reload with the new order
                 getNotes(event.noteOrder)
             }
 
             is NoteListEvent.ToggleOrderSection -> {
-                _state.value = state.value.copy(
-                    isOrderSectionVisible = !state.value.isOrderSectionVisible
-                )
+                _state.update {
+                    it.copy(isOrderSectionVisible = !it.isOrderSectionVisible)
+                }
             }
 
             is NoteListEvent.DeleteNote -> {
@@ -72,8 +74,10 @@ class NoteListViewModel @Inject constructor(
     private fun getNotes(noteOrder: NoteOrder) {
         getNotesJob?.cancel()
         getNotesJob = viewModelScope.launch {
-            getNotesUseCase(noteOrder).collect {
-                _state.value = state.value.copy(notes = it)
+            getNotesUseCase(noteOrder).collect { notes ->
+                _state.update {
+                    it.copy(notes = notes)
+                }
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR replaces `mutableStateOf` with `MutableStateFlow` and `.update {}` for all state mutations, decoupling the ViewModel from the Compose runtime, making state updates atomic and thread-safe, and allowing the ViewModel to be tested in plain JUnit without a Compose test environment.

### Related Issues

Fixes #25.
