### PR TITLE
Fix race condition in `recentlyDeletedNote` handling

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListState.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListState.kt
@@ -7,5 +7,6 @@ import com.oussamateyib.thoth.features.notes.domain.util.OrderType
 data class NoteListState(
     val notes: List<Note> = emptyList(),
     val noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending),
-    val isOrderSectionVisible: Boolean = false
+    val isOrderSectionVisible: Boolean = false,
+    var recentlyDeletedNote: Note? = null
 )

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListViewModel.kt
@@ -2,7 +2,6 @@ package com.oussamateyib.thoth.features.notes.presentation.list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.oussamateyib.thoth.features.notes.domain.model.Note
 import com.oussamateyib.thoth.features.notes.domain.usecase.DeleteNoteUseCase
 import com.oussamateyib.thoth.features.notes.domain.usecase.GetNotesUseCase
 import com.oussamateyib.thoth.features.notes.domain.usecase.InsertNoteUseCase
@@ -27,9 +26,6 @@ class NoteListViewModel @Inject constructor(
 ) : ViewModel() {
     private val _state = MutableStateFlow(NoteListState())
     val state: StateFlow<NoteListState> = _state.asStateFlow()
-
-    // Temporarily holds the last deleted note to support undo
-    private var recentlyDeletedNote: Note? = null
 
     init {
         viewModelScope.launch {
@@ -66,15 +62,20 @@ class NoteListViewModel @Inject constructor(
                 viewModelScope.launch {
                     deleteNoteUseCase(event.note)
                 }
-                recentlyDeletedNote = event.note
+                _state.update {
+                    it.copy(recentlyDeletedNote = event.note)
+                }
             }
 
             is NoteListEvent.RestoreNote -> {
+                val snapshot = _state.value
                 // If no note was recently deleted, do nothing
                 viewModelScope.launch {
-                    insertNoteUseCase(recentlyDeletedNote ?: return@launch)
+                    insertNoteUseCase(snapshot.recentlyDeletedNote ?: return@launch)
                 }
-                recentlyDeletedNote = null
+                _state.update {
+                    it.copy(recentlyDeletedNote = null)
+                }
             }
         }
     }


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Related Issues
Fixes #30
