### PR TITLE
Fix layout issues in list screen

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -98,7 +99,8 @@ fun NoteListScreen(
                     contentDescription = stringResource(R.string.add_note)
                 )
             }
-        }
+        },
+        containerColor = Color.Transparent,
     ) { innerPadding ->
         Column(
             modifier = Modifier
@@ -113,7 +115,7 @@ fun NoteListScreen(
             ) {
                 OrderSection(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .fillMaxWidth()
                         .padding(vertical = 8.dp),
                     noteOrder = state.noteOrder,
                     onOrderChange = {


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description
This PR fixes two layout issues in the note list screen: the background was rendering black due to a missing transparent container color on the `Scaffold`, and the order section was consuming all available vertical space and pushing notes out of view.

### Related Issues
Fixes #32
