### PR TITLE
Add back button to the editor

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/MainActivity.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : ComponentActivity() {
                                 }
                             )
                         ) {
-                            NoteEditorScreen()
+                            NoteEditorScreen(navController = navController)
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import com.oussamateyib.thoth.R
 import com.oussamateyib.thoth.features.notes.presentation.editor.components.ColorPicker
 import com.oussamateyib.thoth.features.notes.presentation.editor.components.TransparentHintTextField
@@ -34,6 +35,7 @@ import com.oussamateyib.thoth.features.notes.presentation.editor.components.Tran
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoteEditorScreen(
+    navController: NavController,
     viewModel: NoteEditorViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -70,6 +72,18 @@ fun NoteEditorScreen(
         topBar = {
             TopAppBar(
                 title = {},
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            navController.popBackStack()
+                        }
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                },
                 actions = {
                     IconButton(
                         onClick = {

--- a/app/src/main/res/drawable/arrow_back.xml
+++ b/app/src/main/res/drawable/arrow_back.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="#1f1f1f" android:pathData="m313,520 l224,224 -57,56 -320,-320 320,-320 57,56 -224,224h487v80L313,520Z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="app_description">Yet another note-taking app</string>
     <string name="app_name">Thoth</string>
     <string name="ascending">Ascending</string>
+    <string name="back">Back</string>
     <string name="color">Color</string>
     <string name="date">Date</string>
     <string name="delete_note">Delete note</string>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a back navigation button to the `NoteEditorScreen` top app bar, allowing users to return to the previous screen via the navigation controller.
