### PR TITLE
Add explicit sheet state to color picker modal

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -51,8 +52,13 @@ fun NoteEditorScreen(
         )
     }
 
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
     if (state.isColorPickerVisible) {
         ModalBottomSheet(
+            sheetState = sheetState,
             onDismissRequest = {
                 viewModel.onEvent(NoteEditorEvent.ToggleColorPicker)
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds explicit bottom sheet state management to the color picker modal in the note editor screen, configuring it to skip the partially expanded state and expand fully when shown.
