### PR TITLE
Handle unexpected navigation and missing note in editor

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -39,6 +41,27 @@ fun NoteEditorScreen(
     viewModel: NoteEditorViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val invalidNavigationMessage = stringResource(R.string.editor_invalid_navigation)
+    val noteNotFoundMessage = stringResource(R.string.note_not_found)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is NoteEditorUiEvent.InvalidNavigation -> {
+                    snackbarHostState.showSnackbar(invalidNavigationMessage)
+                    navController.popBackStack()
+                }
+
+                is NoteEditorUiEvent.NoteNotFound -> {
+                    snackbarHostState.showSnackbar(noteNotFoundMessage)
+                    navController.popBackStack()
+                }
+            }
+        }
+    }
 
     if (state.isLoading) return
 
@@ -75,6 +98,7 @@ fun NoteEditorScreen(
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {},

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorUiEvent.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorUiEvent.kt
@@ -1,0 +1,6 @@
+package com.oussamateyib.thoth.features.notes.presentation.editor
+
+sealed class NoteEditorUiEvent {
+    object InvalidNavigation : NoteEditorUiEvent()
+    object NoteNotFound : NoteEditorUiEvent()
+}

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/editor/NoteEditorViewModel.kt
@@ -11,8 +11,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,38 +28,47 @@ class NoteEditorViewModel @Inject constructor(
     private val _state = MutableStateFlow(NoteEditorState())
     val state: StateFlow<NoteEditorState> = _state.asStateFlow()
 
+    private val _events = MutableSharedFlow<NoteEditorUiEvent>()
+    val events = _events.asSharedFlow()
+
     private var saveJob: Job? = null
 
     init {
-        savedStateHandle.get<Int>("noteId")
-            ?.takeIf { it != -1 }
-            ?.let { noteId ->
-                viewModelScope.launch {
-                    getNoteByIdUseCase(noteId)?.let { note ->
-                        _state.update {
-                            it.copy(
-                                title = NoteEditorTextFieldState(
-                                    text = note.title,
-                                    hint = R.string.note_title_hint,
-                                    isHintVisible = note.title.isEmpty()
-                                ),
-                                content = NoteEditorTextFieldState(
-                                    text = note.content,
-                                    hint = R.string.note_content_hint,
-                                    isHintVisible = note.content.isEmpty()
-                                ),
-                                color = note.color,
-                                id = noteId,
-                                isLoading = false
-                            )
-                        }
-                    }
-                }
-            } ?: {
-            _state.update {
+        when (val noteId = savedStateHandle.get<Int>("noteId")) {
+            null -> viewModelScope.launch {
+                _events.emit(NoteEditorUiEvent.InvalidNavigation)
+            }
+
+            -1 -> _state.update {
                 it.copy(
                     isLoading = false
                 )
+            }
+
+            else -> viewModelScope.launch {
+                when (val note = getNoteByIdUseCase(noteId)) {
+                    null -> viewModelScope.launch {
+                        _events.emit(NoteEditorUiEvent.NoteNotFound)
+                    }
+
+                    else -> _state.update {
+                        it.copy(
+                            title = NoteEditorTextFieldState(
+                                text = note.title,
+                                hint = R.string.note_title_hint,
+                                isHintVisible = note.title.isEmpty()
+                            ),
+                            content = NoteEditorTextFieldState(
+                                text = note.content,
+                                hint = R.string.note_content_hint,
+                                isHintVisible = note.content.isEmpty()
+                            ),
+                            color = note.color,
+                            id = noteId,
+                            isLoading = false
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,10 +9,12 @@
     <string name="date">Date</string>
     <string name="delete_note">Delete note</string>
     <string name="descending">Descending</string>
+    <string name="editor_invalid_navigation">Unable to open the editor. Please try again.</string>
     <string name="pick_color">Pick color</string>
     <string name="list_screen_top_bar_title">My Notes</string>
     <string name="note_content_hint">What’s on your mind…</string>
     <string name="note_deleted">Note deleted</string>
+    <string name="note_not_found">This note could not be found.</string>
     <string name="note_title_hint">Give it a title…</string>
     <string name="title">Title</string>
     <string name="sort_notes">Sort notes</string>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds explicit handling for the case where the `noteId` nav argument is absent entirely, or where the requested note cannot be found in the database. Both cases were either silently ignored or incorrectly treated as a new note flow.

### Changes

- Added `NoteEditorUiEvent` sealed class with `InvalidNavigation` and `NoteNotFound` events.
- Modified `NoteEditorViewModel` to emit the appropriate event for each unhandled case.
- Modified `NoteEditorScreen` to collect UI events and show a snackbar before navigating back.
- Added `editor_invalid_navigation` and `note_not_found` string resources.

### Testing

Manually verified that the normal new note and existing note flows are unaffected.

### Related Issues

Fixes #58.
