### PR TITLE
Rename `getNotes*` to `getNotesStream*`

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/repository/NoteRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/data/repository/NoteRepositoryImpl.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.map
 class NoteRepositoryImpl @Inject constructor(
     private val dao: NoteDao
 ) : NoteRepository {
-    override fun getNotes(): Flow<List<Note>> {
+    override fun getNotesStream(): Flow<List<Note>> {
         return dao.getNotes().map { it.map(NoteEntity::toDomain) }
     }
 

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/repository/NoteRepository.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/repository/NoteRepository.kt
@@ -4,7 +4,7 @@ import com.oussamateyib.thoth.features.notes.domain.model.Note
 import kotlinx.coroutines.flow.Flow
 
 interface NoteRepository {
-    fun getNotes(): Flow<List<Note>>
+    fun getNotesStream(): Flow<List<Note>>
 
     suspend fun getNoteById(id: Int): Note?
 

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/GetNotesUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/domain/usecase/GetNotesUseCase.kt
@@ -8,13 +8,13 @@ import jakarta.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class GetNotesUseCase @Inject constructor(
+class GetNotesStreamUseCase @Inject constructor(
     private val repository: NoteRepository
 ) {
     operator fun invoke(
         noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending)
     ): Flow<List<Note>> {
-        return repository.getNotes().map { notes ->
+        return repository.getNotesStream().map { notes ->
             when (noteOrder) {
                 is NoteOrder.Title -> when (noteOrder.orderType) {
                     is OrderType.Ascending -> notes.sortedBy { it.title.lowercase() }

--- a/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/features/notes/presentation/list/NoteListViewModel.kt
@@ -3,7 +3,7 @@ package com.oussamateyib.thoth.features.notes.presentation.list
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oussamateyib.thoth.features.notes.domain.usecase.DeleteNoteUseCase
-import com.oussamateyib.thoth.features.notes.domain.usecase.GetNotesUseCase
+import com.oussamateyib.thoth.features.notes.domain.usecase.GetNotesStreamUseCase
 import com.oussamateyib.thoth.features.notes.domain.usecase.InsertNoteUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class NoteListViewModel @Inject constructor(
-    getNotesUseCase: GetNotesUseCase,
+    getNotesStreamUseCase: GetNotesStreamUseCase,
     private val deleteNoteUseCase: DeleteNoteUseCase,
     private val insertNoteUseCase: InsertNoteUseCase
 ) : ViewModel() {
@@ -31,7 +31,7 @@ class NoteListViewModel @Inject constructor(
             _state
                 .map { it.noteOrder }
                 .distinctUntilChanged()
-                .flatMapLatest { getNotesUseCase(it) }
+                .flatMapLatest { getNotesStreamUseCase(it) }
                 .collect { notes ->
                     _state.update {
                         it.copy(notes = notes)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

From the [docs](https://developer.android.com/topic/architecture/recommendations#naming-conventions):
> When a class exposes a `Flow` stream or any other stream, the naming convention is `get{model}Stream`—for example, `getAuthorStream(): Flow<Author>`. If the function returns a list of models, use the plural model name: `getAuthorsStream(): Flow<List<Author>>`.
