### PR TITLE
Suppress `NewerVersionAvailable` lint warning

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="NewerVersionAvailable" severity="ignore" />
+</lint>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a `lint.xml` configuration file to suppress the `NewerVersionAvailable` lint warning, keeping lint output focused on actionable issues.
