### PR TITLE
Migrate dependency injection namespace from Jakarta to Javax

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -151,7 +151,7 @@ dependencies {
     implementation(libs.dagger.hilt.core)
     implementation(libs.hilt.android)
     implementation(libs.hilt.lifecycle.viewmodel.compose)
-    implementation(libs.jakarta.inject.api)
+    implementation(libs.javax.inject)
     ksp(libs.hilt.compiler)
 
     // Data persistence

--- a/app/src/main/kotlin/com/oussamateyib/thoth/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/di/DatabaseModule.kt
@@ -8,7 +8,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import jakarta.inject.Singleton
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/data/repository/NoteRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/data/repository/NoteRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.oussamateyib.thoth.feature.notes.data.mappers.toDomain
 import com.oussamateyib.thoth.feature.notes.data.mappers.toEntity
 import com.oussamateyib.thoth.feature.notes.domain.model.Note
 import com.oussamateyib.thoth.feature.notes.domain.repository.NoteRepository
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/di/NotesModule.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/di/NotesModule.kt
@@ -6,7 +6,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import jakarta.inject.Singleton
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/DeleteNoteUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/DeleteNoteUseCase.kt
@@ -2,7 +2,7 @@ package com.oussamateyib.thoth.feature.notes.domain.usecase
 
 import com.oussamateyib.thoth.feature.notes.domain.model.Note
 import com.oussamateyib.thoth.feature.notes.domain.repository.NoteRepository
-import jakarta.inject.Inject
+import javax.inject.Inject
 
 class DeleteNoteUseCase @Inject constructor(
     private val repository: NoteRepository

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/GetNoteByIdUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/GetNoteByIdUseCase.kt
@@ -2,7 +2,7 @@ package com.oussamateyib.thoth.feature.notes.domain.usecase
 
 import com.oussamateyib.thoth.feature.notes.domain.model.Note
 import com.oussamateyib.thoth.feature.notes.domain.repository.NoteRepository
-import jakarta.inject.Inject
+import javax.inject.Inject
 
 class GetNoteByIdUseCase @Inject constructor(
     private val repository: NoteRepository

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/GetNotesUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/GetNotesUseCase.kt
@@ -4,7 +4,7 @@ import com.oussamateyib.thoth.feature.notes.domain.model.Note
 import com.oussamateyib.thoth.feature.notes.domain.repository.NoteRepository
 import com.oussamateyib.thoth.feature.notes.domain.util.NoteOrder
 import com.oussamateyib.thoth.feature.notes.domain.util.OrderType
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/InsertNoteUseCase.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/domain/usecase/InsertNoteUseCase.kt
@@ -2,7 +2,7 @@ package com.oussamateyib.thoth.feature.notes.domain.usecase
 
 import com.oussamateyib.thoth.feature.notes.domain.model.Note
 import com.oussamateyib.thoth.feature.notes.domain.repository.NoteRepository
-import jakarta.inject.Inject
+import javax.inject.Inject
 
 class InsertNoteUseCase @Inject constructor(
     private val repository: NoteRepository

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/editor/NoteEditorViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/editor/NoteEditorViewModel.kt
@@ -10,7 +10,7 @@ import com.oussamateyib.thoth.feature.notes.domain.usecase.GetNoteByIdUseCase
 import com.oussamateyib.thoth.feature.notes.domain.usecase.InsertNoteUseCase
 import com.oussamateyib.thoth.feature.notes.navigation.NoteEditorRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/list/NoteListViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/list/NoteListViewModel.kt
@@ -6,7 +6,7 @@ import com.oussamateyib.thoth.feature.notes.domain.usecase.DeleteNoteUseCase
 import com.oussamateyib.thoth.feature.notes.domain.usecase.GetNotesStreamUseCase
 import com.oussamateyib.thoth.feature.notes.domain.usecase.InsertNoteUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jakarta.inject.Inject
+import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ dependencyAnalysis = "3.14.1"
 fragment = "1.8.9"
 hilt = "2.59.2"
 hiltCompose = "1.3.0"
-inject = "2.0.1"
+inject = "1"
 junit = "4.13.2"
 junitAndroidExt = "1.3.0"
 kotlin = "2.3.21"
@@ -61,7 +61,7 @@ dagger-hilt-core = { group = "com.google.dagger", name = "hilt-core", version.re
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltCompose" }
-jakarta-inject-api = { group = "jakarta.inject", name = "jakarta.inject-api", version.ref = "inject" }
+javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "inject" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "serialization" }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR replaces the `jakarta.inject` namespace with the standard `javax.inject` (JSR-330) across the application.

While recent versions of Dagger support Jakarta annotations, the Android ecosystem—specifically Jetpack libraries and Dagger Hilt compile-time code generation—remains deeply integrated with the `javax` namespace. Reverting to `javax` aligns the project with standard Android development baselines, removes redundant dependency configurations, and prevents potential tooling or compilation friction within the Hilt ecosystem.
