### PR TITLE
Hoist UI state and events in Note screens

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/editor/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/editor/NoteEditorScreen.kt
@@ -33,14 +33,11 @@ import com.oussamateyib.thoth.R
 import com.oussamateyib.thoth.feature.notes.presentation.editor.components.ColorPicker
 import com.oussamateyib.thoth.feature.notes.presentation.editor.components.TransparentHintTextField
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoteEditorScreen(
     onBackClick: () -> Unit,
     viewModel: NoteEditorViewModel = hiltViewModel()
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-
     val snackbarHostState = remember { SnackbarHostState() }
 
     val noteNotFoundMessage = stringResource(R.string.note_not_found)
@@ -56,6 +53,24 @@ fun NoteEditorScreen(
         }
     }
 
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    NoteEditorScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onEvent = { event -> viewModel.onEvent(event) },
+        onBackClick = onBackClick
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NoteEditorScreen(
+    state: NoteEditorState,
+    snackbarHostState: SnackbarHostState,
+    onEvent: (NoteEditorEvent) -> Unit,
+    onBackClick: () -> Unit
+) {
     if (state.isLoading) return
 
     val noteBackgroundAnimatable = remember {
@@ -77,13 +92,13 @@ fun NoteEditorScreen(
         ModalBottomSheet(
             sheetState = sheetState,
             onDismissRequest = {
-                viewModel.onEvent(NoteEditorEvent.ToggleColorPicker)
+                onEvent(NoteEditorEvent.ToggleColorPicker)
             }
         ) {
             ColorPicker(
                 selectedColor = state.color,
                 onColorChange = {
-                    viewModel.onEvent(NoteEditorEvent.ChangeColor(it))
+                    onEvent(NoteEditorEvent.ChangeColor(it))
                 },
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
             )
@@ -110,7 +125,7 @@ fun NoteEditorScreen(
                 actions = {
                     IconButton(
                         onClick = {
-                            viewModel.onEvent(NoteEditorEvent.ToggleColorPicker)
+                            onEvent(NoteEditorEvent.ToggleColorPicker)
                         }
                     ) {
                         Icon(
@@ -135,10 +150,10 @@ fun NoteEditorScreen(
                 hint = stringResource(state.title.hint),
                 isHintVisible = state.title.isHintVisible,
                 onValueChange = {
-                    viewModel.onEvent(NoteEditorEvent.EnteredTitle(it))
+                    onEvent(NoteEditorEvent.EnteredTitle(it))
                 },
                 onFocusChange = {
-                    viewModel.onEvent(NoteEditorEvent.ChangeTitleFocus(it))
+                    onEvent(NoteEditorEvent.ChangeTitleFocus(it))
                 },
                 singleLine = true,
                 textStyle = MaterialTheme.typography.headlineMedium,
@@ -149,10 +164,10 @@ fun NoteEditorScreen(
                 hint = stringResource(state.content.hint),
                 isHintVisible = state.content.isHintVisible,
                 onValueChange = {
-                    viewModel.onEvent(NoteEditorEvent.EnteredContent(it))
+                    onEvent(NoteEditorEvent.EnteredContent(it))
                 },
                 onFocusChange = {
-                    viewModel.onEvent(NoteEditorEvent.ChangeContentFocus(it))
+                    onEvent(NoteEditorEvent.ChangeContentFocus(it))
                 },
                 textStyle = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/list/NoteListScreen.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/presentation/list/NoteListScreen.kt
@@ -46,17 +46,34 @@ import com.oussamateyib.thoth.feature.notes.presentation.list.components.NoteIte
 import com.oussamateyib.thoth.feature.notes.presentation.list.components.OrderSection
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoteListScreen(
     onNoteClick: (Int) -> Unit,
     onAddNote: () -> Unit,
     viewModel: NoteListViewModel = hiltViewModel()
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    NoteListScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onEvent = { event -> viewModel.onEvent(event) },
+        onNoteClick = onNoteClick,
+        onAddNote = onAddNote
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NoteListScreen(
+    state: NoteListState,
+    snackbarHostState: SnackbarHostState,
+    onEvent: (NoteListEvent) -> Unit,
+    onNoteClick: (Int) -> Unit,
+    onAddNote: () -> Unit
+) {
     val scope = rememberCoroutineScope()
 
     // Connect the TopAppBar scroll behavior to the Scaffold
@@ -79,7 +96,7 @@ fun NoteListScreen(
                 actions = {
                     IconButton(
                         onClick = {
-                            viewModel.onEvent(NoteListEvent.ToggleOrderSection)
+                            onEvent(NoteListEvent.ToggleOrderSection)
                         }
                     ) {
                         Icon(
@@ -125,7 +142,7 @@ fun NoteListScreen(
                         .padding(vertical = 8.dp),
                     noteOrder = state.noteOrder,
                     onOrderChange = {
-                        viewModel.onEvent(NoteListEvent.Order(it))
+                        onEvent(NoteListEvent.Order(it))
                     }
                 )
             }
@@ -145,7 +162,7 @@ fun NoteListScreen(
                                 onNoteClick(note.id!!)
                             },
                         onDeleteClick = {
-                            viewModel.onEvent(NoteListEvent.DeleteNote(note))
+                            onEvent(NoteListEvent.DeleteNote(note))
                             scope.launch {
                                 val result = snackbarHostState.showSnackbar(
                                     message = noteDeletedMessage,
@@ -153,7 +170,7 @@ fun NoteListScreen(
                                     duration = SnackbarDuration.Short
                                 )
                                 if (result == SnackbarResult.ActionPerformed) {
-                                    viewModel.onEvent(NoteListEvent.RestoreNote)
+                                    onEvent(NoteListEvent.RestoreNote)
                                 }
                             }
                         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

Refactors `NoteEditorScreen` and `NoteListScreen` to follow the state hoisting pattern by splitting each into two composables: a stateful public entry point that holds the ViewModel wiring, and a stateless internal composable that receives state and events as plain parameters. This improves testability, reusability, and separation of concerns.