### PR TITLE
Supress `GradleDependency` lint warning

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <issue id="NewerVersionAvailable" severity="ignore" />
+    <issue id="GradleDependency" severity="ignore" />
 </lint>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR suppresses the `GradleDependency` lint warning in addition to the existing `NewerVersionAvailable` suppression, preventing lint from flagging Gradle dependency version suggestions during builds.
