### PR TITLE
Fix Kotlin metadata version mismatch in annotation processing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,9 @@ dependencies {
     // Color picker
     implementation(libs.colorpicker.compose)
 
+    // Metadata
+    ksp(libs.kotlin.metadata.jvm)
+
     // Testing
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltCompose" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "inject" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-jvm", version.ref = "kotlin" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "serialization" }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR fixes a compile-time failure caused by a transitively pulled metadata parser that didn't support the metadata version produced by the project's Kotlin compiler. Explicitly declaring the parser in the `ksp` scope forces Gradle to upgrade it to match the project's Kotlin version.
