### PR TITLE
Remove redundant `viewModelScope.launch` in `NoteNotFound` event emission

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/presentation/editor/NoteEditorViewModel.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/presentation/editor/NoteEditorViewModel.kt
@@ -48,9 +48,7 @@ class NoteEditorViewModel @AssistedInject constructor(
 
             else -> viewModelScope.launch {
                 when (val note = getNoteByIdUseCase(noteId)) {
-                    null -> viewModelScope.launch {
-                        _events.emit(NoteEditorUiEvent.NoteNotFound)
-                    }
+                    null -> _events.emit(NoteEditorUiEvent.NoteNotFound)
 
                     else -> _state.update {
                         it.copy(


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Related Issues

Fixes #77.
