### PR TITLE
Migrate JVM configuration to Java toolchain

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -4,6 +4,7 @@
       <w>Daos</w>
       <w>Teyib</w>
       <w>aabs</w>
+      <w>codeql</w>
       <w>oussamateyib</w>
       <w>pipefail</w>
       <w>snackbar</w>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,10 +121,10 @@ Thoth/
 
 ### Prerequisites
 
-| Tool        | Version                      |
-|-------------|------------------------------|
-| JDK         | 17                           |
-| Android SDK | Managed automatically by AGP |
+| Tool        | Version                              |
+|-------------|--------------------------------------|
+| JDK         | 17 (Managed automatically by Gradle) |
+| Android SDK | Managed automatically by AGP         |
 
 ### Gradle tasks
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ This is a note-taking app for Android.
 
 ### Prerequisites
 
-Before you begin, ensure you have the following installed:
-
-- **Java Development Kit (JDK)** — JDK 17
-
 If you want to use your own signing key for release builds, set the following environment variables:
 
 - **STORE_FILE** — Path to the keystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 // Detect if the current build is for an Android App Bundle (AAB)
 val isBuildingBundle = gradle.startParameter.taskNames.any { it.lowercase().contains("bundle") }
 
@@ -19,13 +25,6 @@ android {
         targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     splits {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -5,17 +5,18 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.oussamateyib.thoth.core.data"
     compileSdk = 37
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     alias(libs.plugins.room)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 // Configure Room schema export directory
 room {
     schemaDirectory("$projectDir/schemas")
@@ -16,11 +22,6 @@ android {
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -4,17 +4,18 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.oussamateyib.thoth.core.designsystem"
     compileSdk = 37
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -3,17 +3,18 @@ plugins {
     alias(libs.plugins.dependency.analysis)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.oussamateyib.thoth.core.domain"
     compileSdk = 37
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -4,17 +4,18 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.oussamateyib.thoth.core.navigation"
     compileSdk = 37
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/feature/notes/api/build.gradle.kts
+++ b/feature/notes/api/build.gradle.kts
@@ -4,17 +4,18 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.oussamateyib.thoth.feature.notes.api"
     compileSdk = 37
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/feature/notes/impl/build.gradle.kts
+++ b/feature/notes/impl/build.gradle.kts
@@ -6,17 +6,18 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.oussamateyib.thoth.feature.notes.impl"
     compileSdk = 37
 
     defaultConfig {
         minSdk = 24
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,3 @@
-// Plugin repositories
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -13,7 +12,10 @@ pluginManagement {
     }
 }
 
-// Dependency repositories
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adopts the Java toolchain approach, where a single declaration covers Java and Kotlin compilation and automatically supplies source and target compatibility. Gradle also handles JDK provisioning automatically via a toolchain resolver, so developers no longer need to install JDK manually.

### Reference

- [Android docs](https://developer.android.com/build/jdks#toolchain)
- [Kotlin docs](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support)
