### PR TITLE
Suppress `AndroidGradlePluginVersion` lint warning

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-    <issue id="NewerVersionAvailable" severity="ignore" />
+    <issue id="AndroidGradlePluginVersion" severity="ignore" />
     <issue id="GradleDependency" severity="ignore" />
+    <issue id="NewerVersionAvailable" severity="ignore" />
 </lint>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR suppresses the `AndroidGradlePluginVersion` lint warning, preventing lint from flagging the Gradle wrapper version as outdated and failing the build.
