### PR TITLE
Make the note editor screen scrollable vertically

### DIFF
--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -106,6 +108,8 @@ internal fun NoteEditorScreen(
         }
     }
 
+    val verticalScroll = rememberScrollState()
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
@@ -145,6 +149,7 @@ internal fun NoteEditorScreen(
                 .background(noteBackgroundAnimatable.value)
                 .padding(innerPadding)
                 .padding(horizontal = 20.dp, vertical = 12.dp)
+                .verticalScroll(verticalScroll)
         ) {
             TransparentTextField(
                 value = state.title.text,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR makes the note editor screen scrollable vertically, allowing the content to scroll when it exceeds the visible screen height.