### PR TITLE
Pin top bar during selection mode

### DIFF
--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
@@ -79,9 +79,6 @@ internal fun NoteListScreen(
 ) {
     val scope = rememberCoroutineScope()
 
-    // Connect the TopAppBar scroll behavior to the Scaffold
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-
     // Clear selection when back button is pressed in selection mode
     BackHandler(enabled = state.isSelectionMode) {
         onEvent(NoteListEvent.ClearSelection)
@@ -106,11 +103,19 @@ internal fun NoteListScreen(
         }
     }
 
+    val scrollBehavior = if (state.isSelectionMode) {
+        TopAppBarDefaults.pinnedScrollBehavior()
+    } else {
+        TopAppBarDefaults.enterAlwaysScrollBehavior()
+    }
+
     val selectedNotesDeletedMessage = stringResource(R.string.selected_notes_deleted)
     val undoLabel = stringResource(R.string.undo)
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            // Connect scroll events from the content to the top bar behavior
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR fixes the top bar collapsing during selection mode, which was hiding the selection actions (color picker and delete) from the user. The scroll behavior is now chosen conditionally based on whether selection mode is active.