### PR TITLE
Replace nullable note IDs with non-null zero-defaulted integers

### DIFF
--- a/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/NotesRepository.kt
+++ b/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/NotesRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface NotesRepository {
     fun getNotesStream(): Flow<List<Note>>
 
-    suspend fun getNoteById(id: Int): Note?
+    suspend fun getNoteById(id: Long): Note?
 
     suspend fun insertNote(note: Note): Long
 

--- a/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/OfflineFirstNotesRepository.kt
+++ b/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/OfflineFirstNotesRepository.kt
@@ -15,7 +15,7 @@ internal class OfflineFirstNotesRepository @Inject constructor(
         it.map(NoteEntity::asExternalModel)
     }
 
-    override suspend fun getNoteById(id: Int) = dao.getNoteById(id)?.asExternalModel()
+    override suspend fun getNoteById(id: Long) = dao.getNoteById(id)?.asExternalModel()
 
     override suspend fun insertNote(note: Note) = dao.insertNote(note.asEntity())
 

--- a/core/database/schemas/com.oussamateyib.thoth.core.database.ThothDatabase/1.json
+++ b/core/database/schemas/com.oussamateyib.thoth.core.database.ThothDatabase/1.json
@@ -2,16 +2,17 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "25039845c72d1c7c51a3555e95d0e622",
+    "identityHash": "059d234f6c63aba320932a9370ba7b30",
     "entities": [
       {
         "tableName": "notes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `color` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `color` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
             "columnName": "id",
-            "affinity": "INTEGER"
+            "affinity": "INTEGER",
+            "notNull": true
           },
           {
             "fieldPath": "title",
@@ -39,7 +40,7 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": false,
+          "autoGenerate": true,
           "columnNames": [
             "id"
           ]
@@ -48,7 +49,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '25039845c72d1c7c51a3555e95d0e622')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '059d234f6c63aba320932a9370ba7b30')"
     ]
   }
 }

--- a/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/dao/NoteDao.kt
+++ b/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/dao/NoteDao.kt
@@ -14,7 +14,7 @@ interface NoteDao {
     fun getNotes(): Flow<List<NoteEntity>>
 
     @Query("SELECT * FROM notes WHERE id = :id")
-    suspend fun getNoteById(id: Int): NoteEntity?
+    suspend fun getNoteById(id: Long): NoteEntity?
 
     // Replace the note if it already exists
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/model/NoteEntity.kt
+++ b/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/model/NoteEntity.kt
@@ -7,8 +7,8 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 
 @Entity(tableName = "notes")
 data class NoteEntity(
-    @PrimaryKey
-    val id: Int? = null,
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
     val title: String,
     val content: String,
     val timestamp: Long,

--- a/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/GetNoteByIdUseCase.kt
+++ b/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/GetNoteByIdUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class GetNoteByIdUseCase @Inject constructor(
     private val repository: NotesRepository
 ) {
-    suspend operator fun invoke(id: Int) = repository.getNoteById(id)
+    suspend operator fun invoke(id: Long) = repository.getNoteById(id)
 }

--- a/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/Note.kt
+++ b/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/Note.kt
@@ -1,7 +1,7 @@
 package com.oussamateyib.thoth.core.model.data
 
 data class Note(
-    val id: Int? = null,
+    val id: Long = 0L,
     val title: String,
     val content: String,
     val timestamp: Long,

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItemList.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItemList.kt
@@ -10,21 +10,21 @@ import com.oussamateyib.thoth.core.model.data.Note
 
 fun LazyListScope.noteItems(
     items: List<Note>,
-    selectedItems: Set<Int>,
-    onNoteClick: (Int) -> Unit,
-    onNoteLongClick: (Int) -> Unit,
+    selectedItems: Set<Long>,
+    onNoteClick: (Long) -> Unit,
+    onNoteLongClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) = items(
     items = items,
     // Assigns unique identifiers to optimize list state and reordering performance
-    key = { it.id!! }
+    key = { it.id }
 ) { note ->
     NoteItem(
         note = note,
         isSelected = selectedItems.contains(note.id),
         modifier = modifier,
-        onClick = { onNoteClick(note.id!!) },
-        onLongClick = { onNoteLongClick(note.id!!) }
+        onClick = { onNoteClick(note.id) },
+        onLongClick = { onNoteLongClick(note.id) }
     )
     Spacer(modifier = Modifier.height(16.dp))
 }

--- a/feature/notes/api/src/main/kotlin/com/oussamateyib/thoth/feature/notes/api/NotesNavKey.kt
+++ b/feature/notes/api/src/main/kotlin/com/oussamateyib/thoth/feature/notes/api/NotesNavKey.kt
@@ -7,4 +7,4 @@ import kotlinx.serialization.Serializable
 data object NoteListNavKey : NavKey
 
 @Serializable
-data class NoteEditorNavKey(val noteId: Int = -1) : NavKey
+data class NoteEditorNavKey(val noteId: Long = 0L) : NavKey

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorState.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorState.kt
@@ -4,7 +4,7 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 import com.oussamateyib.thoth.feature.notes.impl.R
 
 data class NoteEditorState(
-    val id: Int? = null,
+    val id: Long = 0L,
     val title: NoteEditorTextFieldState = NoteEditorTextFieldState(hint = R.string.note_title_hint),
     val content: NoteEditorTextFieldState = NoteEditorTextFieldState(hint = R.string.note_content_hint),
     val color: NoteColor = NoteColor.Default,

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
@@ -22,13 +22,13 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @HiltViewModel(assistedFactory = NoteEditorViewModel.Factory::class)
 class NoteEditorViewModel @AssistedInject constructor(
-    @Assisted private val noteId: Int,
+    @Assisted private val noteId: Long,
     getNoteByIdUseCase: GetNoteByIdUseCase,
     private val insertNoteUseCase: InsertNoteUseCase
 ) : ViewModel() {
     @AssistedFactory
     interface Factory {
-        fun create(noteId: Int): NoteEditorViewModel
+        fun create(noteId: Long): NoteEditorViewModel
     }
 
     private val _state = MutableStateFlow(NoteEditorState())
@@ -41,10 +41,8 @@ class NoteEditorViewModel @AssistedInject constructor(
 
     init {
         when (noteId) {
-            -1 -> _state.update {
-                it.copy(
-                    isLoading = false
-                )
+            0L -> _state.update {
+                it.copy(isLoading = false)
             }
 
             else -> viewModelScope.launch {
@@ -53,6 +51,7 @@ class NoteEditorViewModel @AssistedInject constructor(
 
                     else -> _state.update {
                         it.copy(
+                            id = noteId,
                             title = NoteEditorTextFieldState(
                                 text = note.title,
                                 hint = R.string.note_title_hint,
@@ -64,7 +63,6 @@ class NoteEditorViewModel @AssistedInject constructor(
                                 isHintVisible = note.content.isEmpty()
                             ),
                             color = note.color,
-                            id = noteId,
                             isLoading = false
                         )
                     }
@@ -142,17 +140,19 @@ class NoteEditorViewModel @AssistedInject constructor(
             with(_state.value) {
                 val newId = insertNoteUseCase(
                     Note(
+                        id = id,
                         title = title.text,
                         content = content.text,
                         timestamp = System.currentTimeMillis(),
-                        color = color,
-                        id = id
+                        color = color
                     )
                 )
 
                 // Update the state with the new ID if this was a newly created note
-                id ?: _state.update {
-                    it.copy(id = newId.toInt())
+                if (id == 0L) {
+                    _state.update {
+                        it.copy(id = newId)
+                    }
                 }
             }
         }

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListEvent.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListEvent.kt
@@ -6,7 +6,7 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 sealed class NoteListEvent {
     data class Order(val noteOrder: NoteOrder) : NoteListEvent()
     object ToggleSortSheet : NoteListEvent()
-    data class SelectNote(val id: Int) : NoteListEvent()
+    data class SelectNote(val id: Long) : NoteListEvent()
     object ClearSelection : NoteListEvent()
     object DeleteSelectedNotes : NoteListEvent()
     object RestoreDeletedNotes : NoteListEvent()

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun NoteListScreen(
-    onNoteClick: (Int) -> Unit,
+    onNoteClick: (Long) -> Unit,
     onAddNote: () -> Unit,
     viewModel: NoteListViewModel
 ) {
@@ -65,7 +65,7 @@ internal fun NoteListScreen(
     state: NoteListState,
     snackbarHostState: SnackbarHostState,
     onEvent: (NoteListEvent) -> Unit,
-    onNoteClick: (Int) -> Unit,
+    onNoteClick: (Long) -> Unit,
     onAddNote: () -> Unit
 ) {
     val scope = rememberCoroutineScope()

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListState.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListState.kt
@@ -7,7 +7,7 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 
 data class NoteListState(
     val notes: List<Note> = emptyList(),
-    val selectedNoteIds: Set<Int> = emptySet(),
+    val selectedNoteIds: Set<Long> = emptySet(),
     val noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending),
     val isSortSheetVisible: Boolean = false,
     val isColorPickerVisible: Boolean = false,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR replaces nullable note IDs with non-null long integers defaulting to zero to represent a new/unsaved note. This eliminates null checks and non-null assertions scattered across the codebase, and aligns the sentinel value for "no ID yet" from `-1` to `0L`.
