### PR TITLE
Enable Compose tooling in Android Studio

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,10 @@ android {
         versionName = "1.0.0"
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     splits {
         abi {
             // Disable ABI splits when building an App Bundle to avoid conflicts

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         minSdk = 24
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     lint {
         checkAllWarnings = true
         warningsAsErrors = true

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         minSdk = 24
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     lint {
         checkAllWarnings = true
         warningsAsErrors = true

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         minSdk = 24
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     lint {
         checkAllWarnings = true
         warningsAsErrors = true

--- a/feature/notes/impl/build.gradle.kts
+++ b/feature/notes/impl/build.gradle.kts
@@ -20,6 +20,10 @@ android {
         minSdk = 24
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     lint {
         checkAllWarnings = true
         warningsAsErrors = true


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR enables AGP's `buildFeatures.compose` flag on modules that use Compose to unlock tooling support in Android Studio, including `@Preview` rendering and Layout Inspector.