### PR TITLE
Improve note editor input experience and fix note item preview rendering

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -8,7 +8,7 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.compose.foundation)
+    api(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.foundation.layout)
     api(libs.androidx.compose.material3)
     api(libs.androidx.compose.runtime)

--- a/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
@@ -21,13 +21,11 @@ fun TransparentTextField(
     textStyle: TextStyle = TextStyle.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    isHintVisible: Boolean = true,
-    singleLine: Boolean = false
+    isHintVisible: Boolean = true
 ) {
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
-        singleLine = singleLine,
         textStyle = textStyle.copy(color = LocalContentColor.current),
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,

--- a/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
@@ -2,6 +2,7 @@ package com.oussamateyib.thoth.core.designsystem.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,8 +18,9 @@ fun TransparentTextField(
     hint: String,
     onValueChange: (String) -> Unit,
     onFocusChange: (FocusState) -> Unit,
-    textStyle: TextStyle,
     modifier: Modifier = Modifier,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     isHintVisible: Boolean = true,
     singleLine: Boolean = false
 ) {
@@ -27,6 +29,7 @@ fun TransparentTextField(
         onValueChange = onValueChange,
         singleLine = singleLine,
         textStyle = textStyle.copy(color = LocalContentColor.current),
+        keyboardOptions = keyboardOptions,
         modifier = modifier
             .onFocusChanged {
                 onFocusChange(it)

--- a/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
@@ -2,6 +2,7 @@ package com.oussamateyib.thoth.core.designsystem.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -11,15 +12,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 
 @Composable
 fun TransparentTextField(
-    value: String,
+    value: TextFieldValue,
     hint: String,
-    onValueChange: (String) -> Unit,
+    onValueChange: (TextFieldValue) -> Unit,
     onFocusChange: (FocusState) -> Unit,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = TextStyle.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     isHintVisible: Boolean = true,
     singleLine: Boolean = false
@@ -29,6 +32,7 @@ fun TransparentTextField(
         onValueChange = onValueChange,
         singleLine = singleLine,
         textStyle = textStyle.copy(color = LocalContentColor.current),
+        keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         modifier = modifier
             .onFocusChanged {

--- a/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
@@ -9,8 +9,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusState
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 
@@ -19,7 +17,6 @@ fun TransparentTextField(
     value: TextFieldValue,
     hint: String,
     onValueChange: (TextFieldValue) -> Unit,
-    onFocusChange: (FocusState) -> Unit,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = TextStyle.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -34,10 +31,7 @@ fun TransparentTextField(
         textStyle = textStyle.copy(color = LocalContentColor.current),
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
-        modifier = modifier
-            .onFocusChanged {
-                onFocusChange(it)
-            },
+        modifier = modifier,
         decorationBox = { innerTextField ->
             Box {
                 if (isHintVisible) {

--- a/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.text.TextStyle
 fun TransparentTextField(
     value: String,
     hint: String,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (FocusState) -> Unit,
+    textStyle: TextStyle,
     modifier: Modifier = Modifier,
     isHintVisible: Boolean = true,
-    onValueChange: (String) -> Unit,
-    textStyle: TextStyle,
-    singleLine: Boolean = false,
-    onFocusChange: (FocusState) -> Unit
+    singleLine: Boolean = false
 ) {
     BasicTextField(
         value = value,

--- a/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/oussamateyib/thoth/core/designsystem/components/TransparentTextField.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextDirection
 
 @Composable
 fun TransparentTextField(
@@ -26,12 +27,18 @@ fun TransparentTextField(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
-        textStyle = textStyle.copy(color = LocalContentColor.current),
+        textStyle = textStyle.copy(
+            color = LocalContentColor.current,
+            textDirection = TextDirection.Content
+        ),
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         modifier = modifier,
         decorationBox = { innerTextField ->
-            Box {
+            Box(
+                // Ensure children occupy the full width
+                propagateMinConstraints = true
+            ) {
                 if (isHintVisible) {
                     Text(
                         text = hint,

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
@@ -52,19 +52,23 @@ fun NoteItem(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
-            Text(
-                text = note.title,
-                style = MaterialTheme.typography.titleLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = note.content,
-                style = MaterialTheme.typography.bodyMedium,
-                maxLines = 10,
-                overflow = TextOverflow.Ellipsis
-            )
+            if (!note.title.isEmpty()) {
+                Text(
+                    text = note.title,
+                    style = MaterialTheme.typography.titleLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            if (!note.content.isEmpty()) {
+                if (note.title.isNotEmpty()) Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = note.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 10,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CardDefaults
@@ -16,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.oussamateyib.thoth.core.model.data.Note
@@ -55,17 +57,23 @@ fun NoteItem(
             if (!note.title.isEmpty()) {
                 Text(
                     text = note.title,
-                    style = MaterialTheme.typography.titleLarge,
-                    overflow = TextOverflow.Ellipsis
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        textDirection = TextDirection.Content
+                    ),
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
             if (!note.content.isEmpty()) {
                 if (note.title.isNotEmpty()) Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = note.content,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        textDirection = TextDirection.Content
+                    ),
                     maxLines = 10,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         }

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
@@ -24,9 +24,9 @@ import com.oussamateyib.thoth.core.model.data.Note
 fun NoteItem(
     note: Note,
     isSelected: Boolean,
-    modifier: Modifier = Modifier,
     onClick: () -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val containerColor = note.color.asColor()
 

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItem.kt
@@ -56,7 +56,6 @@ fun NoteItem(
                 Text(
                     text = note.title,
                     style = MaterialTheme.typography.titleLarge,
-                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
             }

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItemList.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteItemList.kt
@@ -16,7 +16,7 @@ fun LazyListScope.noteItems(
     modifier: Modifier = Modifier
 ) = items(
     items = items,
-    // Assigns unique identifiers to optimize list state and reordering performance
+    // Assign unique identifiers to optimize list state and reordering performance
     key = { it.id }
 ) { note ->
     NoteItem(

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteSortSheet.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteSortSheet.kt
@@ -28,9 +28,9 @@ import com.oussamateyib.thoth.core.domain.util.OrderType
 
 @Composable
 fun NoteSortSheet(
+    onOrderChange: (NoteOrder) -> Unit,
     modifier: Modifier = Modifier,
-    noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending),
-    onOrderChange: (NoteOrder) -> Unit
+    noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending)
 ) {
     Column(
         modifier = modifier

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorEvent.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorEvent.kt
@@ -5,9 +5,7 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 
 sealed class NoteEditorEvent {
     data class EnteredTitle(val title: String) : NoteEditorEvent()
-    data class ChangeTitleFocus(val focusState: FocusState) : NoteEditorEvent()
     data class EnteredContent(val content: String) : NoteEditorEvent()
-    data class ChangeContentFocus(val focusState: FocusState) : NoteEditorEvent()
     data class ChangeColor(val color: NoteColor) : NoteEditorEvent()
     object ToggleColorPicker : NoteEditorEvent()
 }

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
@@ -187,13 +187,10 @@ internal fun NoteEditorScreen(
             TransparentTextField(
                 value = titleFieldValue,
                 hint = stringResource(state.title.hint),
-                isHintVisible = state.title.isHintVisible,
+                isHintVisible = state.title.text.isEmpty(),
                 onValueChange = {
                     titleFieldValue = it
                     onEvent(NoteEditorEvent.EnteredTitle(it.text))
-                },
-                onFocusChange = {
-                    onEvent(NoteEditorEvent.ChangeTitleFocus(it))
                 },
                 singleLine = true,
                 textStyle = MaterialTheme.typography.headlineMedium,
@@ -215,13 +212,10 @@ internal fun NoteEditorScreen(
             TransparentTextField(
                 value = contentFieldValue,
                 hint = stringResource(state.content.hint),
-                isHintVisible = state.content.isHintVisible,
+                isHintVisible = state.content.text.isEmpty(),
                 onValueChange = {
                     contentFieldValue = it
                     onEvent(NoteEditorEvent.EnteredContent(it.text))
-                },
-                onFocusChange = {
-                    onEvent(NoteEditorEvent.ChangeContentFocus(it))
                 },
                 textStyle = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,12 +27,18 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.oussamateyib.thoth.core.designsystem.components.TransparentTextField
@@ -115,6 +122,15 @@ internal fun NoteEditorScreen(
         }
     }
 
+    var titleFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = state.title.text))
+    }
+    var contentFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = state.content.text))
+    }
+
+    val contentFocusRequester = remember { FocusRequester() }
+
     val verticalScroll = rememberScrollState()
 
     Scaffold(
@@ -162,11 +178,12 @@ internal fun NoteEditorScreen(
                 .verticalScroll(verticalScroll)
         ) {
             TransparentTextField(
-                value = state.title.text,
+                value = titleFieldValue,
                 hint = stringResource(state.title.hint),
                 isHintVisible = state.title.isHintVisible,
                 onValueChange = {
-                    onEvent(NoteEditorEvent.EnteredTitle(it))
+                    titleFieldValue = it
+                    onEvent(NoteEditorEvent.EnteredTitle(it.text))
                 },
                 onFocusChange = {
                     onEvent(NoteEditorEvent.ChangeTitleFocus(it))
@@ -176,21 +193,33 @@ internal fun NoteEditorScreen(
                 keyboardOptions = KeyboardOptions.Default.copy(
                     imeAction = ImeAction.Next
                 ),
+                keyboardActions = KeyboardActions(
+                    onNext = {
+                        // Move focus to the content field and place the cursor at the end
+                        contentFocusRequester.requestFocus()
+                        contentFieldValue = contentFieldValue.copy(
+                            selection = TextRange(contentFieldValue.text.length)
+                        )
+                    }
+                ),
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(modifier = Modifier.height(12.dp))
             TransparentTextField(
-                value = state.content.text,
+                value = contentFieldValue,
                 hint = stringResource(state.content.hint),
                 isHintVisible = state.content.isHintVisible,
                 onValueChange = {
-                    onEvent(NoteEditorEvent.EnteredContent(it))
+                    contentFieldValue = it
+                    onEvent(NoteEditorEvent.EnteredContent(it.text))
                 },
                 onFocusChange = {
                     onEvent(NoteEditorEvent.ChangeContentFocus(it))
                 },
                 textStyle = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(contentFocusRequester)
             )
         }
     }

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -30,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.oussamateyib.thoth.core.designsystem.components.TransparentTextField
@@ -171,6 +173,9 @@ internal fun NoteEditorScreen(
                 },
                 singleLine = true,
                 textStyle = MaterialTheme.typography.headlineMedium,
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Next
+                ),
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(modifier = Modifier.height(12.dp))

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
@@ -192,7 +192,6 @@ internal fun NoteEditorScreen(
                     titleFieldValue = it
                     onEvent(NoteEditorEvent.EnteredTitle(it.text))
                 },
-                singleLine = true,
                 textStyle = MaterialTheme.typography.headlineMedium,
                 keyboardOptions = KeyboardOptions.Default.copy(
                     imeAction = ImeAction.Next

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorScreen.kt
@@ -131,6 +131,13 @@ internal fun NoteEditorScreen(
 
     val contentFocusRequester = remember { FocusRequester() }
 
+    // Autofocus the content field when opening a new note
+    LaunchedEffect(Unit) {
+        if (state.id == 0L) {
+            contentFocusRequester.requestFocus()
+        }
+    }
+
     val verticalScroll = rememberScrollState()
 
     Scaffold(

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorTextFieldState.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorTextFieldState.kt
@@ -4,6 +4,5 @@ import androidx.annotation.StringRes
 
 data class NoteEditorTextFieldState(
     val text: String = "",
-    @param:StringRes val hint: Int = 0,
-    val isHintVisible: Boolean = true
+    @param:StringRes val hint: Int = 0
 )

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
@@ -54,13 +54,11 @@ class NoteEditorViewModel @AssistedInject constructor(
                             id = noteId,
                             title = NoteEditorTextFieldState(
                                 text = note.title,
-                                hint = R.string.note_title_hint,
-                                isHintVisible = note.title.isEmpty()
+                                hint = R.string.note_title_hint
                             ),
                             content = NoteEditorTextFieldState(
                                 text = note.content,
-                                hint = R.string.note_content_hint,
-                                isHintVisible = note.content.isEmpty()
+                                hint = R.string.note_content_hint
                             ),
                             color = note.color,
                             isLoading = false
@@ -84,16 +82,6 @@ class NoteEditorViewModel @AssistedInject constructor(
                 saveNote()
             }
 
-            is NoteEditorEvent.ChangeTitleFocus -> {
-                _state.update {
-                    it.copy(
-                        title = it.title.copy(
-                            isHintVisible = !event.focusState.isFocused && it.title.text.isEmpty()
-                        )
-                    )
-                }
-            }
-
             is NoteEditorEvent.EnteredContent -> {
                 _state.update {
                     it.copy(
@@ -103,16 +91,6 @@ class NoteEditorViewModel @AssistedInject constructor(
                     )
                 }
                 saveNote()
-            }
-
-            is NoteEditorEvent.ChangeContentFocus -> {
-                _state.update {
-                    it.copy(
-                        content = it.content.copy(
-                            isHintVisible = !event.focusState.isFocused && it.content.text.isEmpty()
-                        )
-                    )
-                }
             }
 
             is NoteEditorEvent.ChangeColor -> {

--- a/feature/notes/impl/src/main/res/values/strings.xml
+++ b/feature/notes/impl/src/main/res/values/strings.xml
@@ -6,9 +6,9 @@
     <string name="clear_selection">Clear selection</string>
     <string name="delete_selected_notes">Delete selected notes</string>
     <string name="list_screen_top_bar_title">Notes</string>
-    <string name="note_content_hint">What’s on your mind…</string>
+    <string name="note_content_hint">Note</string>
     <string name="note_not_found">This note could not be found.</string>
-    <string name="note_title_hint">Give it a title…</string>
+    <string name="note_title_hint">Title</string>
     <string name="selected_notes_deleted">Selected notes deleted</string>
     <string name="sort_notes">Sort notes</string>
     <string name="undo">Undo</string>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR improves the note editor input experience and fixes several UI rendering issues in the note item preview.

### Changes
- Improved note editor input experience by migrating text fields to `TextFieldValue` for proper cursor and selection state management.
- Added autofocus on the content field when opening a new note.
- When pressing `Next` on the title field, focus moves to the content field with the cursor placed at the end.
- Simplified hint visibility logic — derived directly from whether the text is empty, removing the need for focus-tracking events and ViewModel state.
- Hidden empty title and content sections in the note item preview.
- Removed the single-line constraint from the title field and the `maxLines` limit from the note preview title.
- Enforced proper bidirectional text rendering across text fields and note item preview.