### PR TITLE
Migrate timestamps to `Instant`

### DIFF
--- a/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/ThothDatabase.kt
+++ b/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/ThothDatabase.kt
@@ -2,13 +2,16 @@ package com.oussamateyib.thoth.core.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.oussamateyib.thoth.core.database.dao.NoteDao
 import com.oussamateyib.thoth.core.database.model.NoteEntity
+import com.oussamateyib.thoth.core.database.util.InstantConverter
 
 @Database(
     entities = [NoteEntity::class],
     version = 1
 )
+@TypeConverters(InstantConverter::class)
 internal abstract class ThothDatabase : RoomDatabase() {
     abstract fun noteDao(): NoteDao
 }

--- a/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/model/NoteEntity.kt
+++ b/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/model/NoteEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.oussamateyib.thoth.core.model.data.Note
 import com.oussamateyib.thoth.core.model.data.NoteColor
+import kotlin.time.Instant
 
 @Entity(tableName = "notes")
 data class NoteEntity(
@@ -11,7 +12,7 @@ data class NoteEntity(
     val id: Long = 0L,
     val title: String,
     val content: String,
-    val timestamp: Long,
+    val timestamp: Instant,
     val color: NoteColor
 )
 

--- a/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/util/InstantConvertor.kt
+++ b/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/util/InstantConvertor.kt
@@ -1,0 +1,12 @@
+package com.oussamateyib.thoth.core.database.util
+
+import androidx.room.TypeConverter
+import kotlin.time.Instant
+
+internal class InstantConverter {
+    @TypeConverter
+    fun longToInstant(value: Long?) = value?.let(Instant::fromEpochMilliseconds)
+
+    @TypeConverter
+    fun instantToLong(instant: Instant?) = instant?.toEpochMilliseconds()
+}

--- a/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/DeleteNoteUseCase.kt
+++ b/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/DeleteNoteUseCase.kt
@@ -7,7 +7,5 @@ import javax.inject.Inject
 class DeleteNoteUseCase @Inject constructor(
     private val repository: NotesRepository
 ) {
-    suspend operator fun invoke(note: Note) {
-        repository.deleteNote(note)
-    }
+    suspend operator fun invoke(note: Note) = repository.deleteNote(note)
 }

--- a/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/Note.kt
+++ b/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/Note.kt
@@ -1,9 +1,11 @@
 package com.oussamateyib.thoth.core.model.data
 
+import kotlin.time.Instant
+
 data class Note(
     val id: Long = 0L,
     val title: String,
     val content: String,
-    val timestamp: Long,
+    val timestamp: Instant,
     val color: NoteColor
 )

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 
 @HiltViewModel(assistedFactory = NoteEditorViewModel.Factory::class)
@@ -121,7 +122,7 @@ class NoteEditorViewModel @AssistedInject constructor(
                         id = id,
                         title = title.text,
                         content = content.text,
-                        timestamp = System.currentTimeMillis(),
+                        timestamp = Clock.System.now(),
                         color = color
                     )
                 )


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR replaces raw `Long` epoch milliseconds with `Instant` for timestamp fields across the data model and database layers, and introduces a Room `TypeConverter` to handle the serialization transparently.
