### PR TITLE
Split timestamp into `createdAt` and `updatedAt` fields

### DIFF
--- a/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/model/Note.kt
+++ b/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/model/Note.kt
@@ -7,6 +7,7 @@ internal fun Note.asEntity(): NoteEntity = NoteEntity(
     id = id,
     title = title,
     content = content,
-    timestamp = timestamp,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
     color = color
 )

--- a/core/database/schemas/com.oussamateyib.thoth.core.database.ThothDatabase/1.json
+++ b/core/database/schemas/com.oussamateyib.thoth.core.database.ThothDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "059d234f6c63aba320932a9370ba7b30",
+    "identityHash": "8e4cc541d1c109fd33ef83d9b8dc9c66",
     "entities": [
       {
         "tableName": "notes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `color` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `color` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -27,8 +27,14 @@
             "notNull": true
           },
           {
-            "fieldPath": "timestamp",
-            "columnName": "timestamp",
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -49,7 +55,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '059d234f6c63aba320932a9370ba7b30')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8e4cc541d1c109fd33ef83d9b8dc9c66')"
     ]
   }
 }

--- a/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/model/NoteEntity.kt
+++ b/core/database/src/main/kotlin/com/oussamateyib/thoth/core/database/model/NoteEntity.kt
@@ -12,7 +12,8 @@ data class NoteEntity(
     val id: Long = 0L,
     val title: String,
     val content: String,
-    val timestamp: Instant,
+    val createdAt: Instant,
+    val updatedAt: Instant,
     val color: NoteColor
 )
 
@@ -20,6 +21,7 @@ fun NoteEntity.asExternalModel(): Note = Note(
     id = id,
     title = title,
     content = content,
-    timestamp = timestamp,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
     color = color
 )

--- a/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/GetNotesUseCase.kt
+++ b/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/GetNotesUseCase.kt
@@ -10,7 +10,7 @@ class GetNotesStreamUseCase @Inject constructor(
     private val repository: NotesRepository
 ) {
     operator fun invoke(
-        noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending)
+        noteOrder: NoteOrder = NoteOrder.DateUpdated(OrderType.Descending)
     ) = repository.getNotesStream().map { notes ->
         when (noteOrder) {
             is NoteOrder.Title -> when (noteOrder.orderType) {
@@ -18,9 +18,14 @@ class GetNotesStreamUseCase @Inject constructor(
                 is OrderType.Descending -> notes.sortedByDescending { it.title.lowercase() }
             }
 
-            is NoteOrder.Date -> when (noteOrder.orderType) {
-                is OrderType.Ascending -> notes.sortedBy { it.timestamp }
-                is OrderType.Descending -> notes.sortedByDescending { it.timestamp }
+            is NoteOrder.DateCreated -> when (noteOrder.orderType) {
+                is OrderType.Ascending -> notes.sortedBy { it.createdAt }
+                is OrderType.Descending -> notes.sortedByDescending { it.createdAt }
+            }
+
+            is NoteOrder.DateUpdated -> when (noteOrder.orderType) {
+                is OrderType.Ascending -> notes.sortedBy { it.updatedAt }
+                is OrderType.Descending -> notes.sortedByDescending { it.updatedAt }
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/util/NoteOrder.kt
+++ b/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/util/NoteOrder.kt
@@ -4,10 +4,12 @@ sealed class NoteOrder(
     val orderType: OrderType
 ) {
     class Title(orderType: OrderType) : NoteOrder(orderType)
-    class Date(orderType: OrderType) : NoteOrder(orderType)
+    class DateCreated(orderType: OrderType) : NoteOrder(orderType)
+    class DateUpdated(orderType: OrderType) : NoteOrder(orderType)
 
     fun copy(orderType: OrderType = this.orderType): NoteOrder = when (this) {
         is Title -> Title(orderType)
-        is Date -> Date(orderType)
+        is DateCreated -> DateCreated(orderType)
+        is DateUpdated -> DateUpdated(orderType)
     }
 }

--- a/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/Note.kt
+++ b/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/Note.kt
@@ -6,6 +6,7 @@ data class Note(
     val id: Long = 0L,
     val title: String,
     val content: String,
-    val timestamp: Instant,
+    val createdAt: Instant,
+    val updatedAt: Instant,
     val color: NoteColor
 )

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteSortSheet.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteSortSheet.kt
@@ -30,7 +30,7 @@ import com.oussamateyib.thoth.core.domain.util.OrderType
 fun NoteSortSheet(
     onOrderChange: (NoteOrder) -> Unit,
     modifier: Modifier = Modifier,
-    noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending)
+    noteOrder: NoteOrder = NoteOrder.DateUpdated(OrderType.Descending)
 ) {
     Column(
         modifier = modifier
@@ -43,15 +43,29 @@ fun NoteSortSheet(
         HorizontalDivider()
         Spacer(modifier = Modifier.height(8.dp))
         SortOptionRow(
-            label = stringResource(R.string.date),
-            selected = noteOrder is NoteOrder.Date,
+            label = stringResource(R.string.date_created),
+            selected = noteOrder is NoteOrder.DateCreated,
             orderType = noteOrder.orderType,
             onClick = {
                 onOrderChange(
-                    if (noteOrder is NoteOrder.Date) {
+                    if (noteOrder is NoteOrder.DateCreated) {
                         noteOrder.copy(noteOrder.orderType.toggle())
                     } else {
-                        NoteOrder.Date(noteOrder.orderType)
+                        NoteOrder.DateCreated(noteOrder.orderType)
+                    }
+                )
+            }
+        )
+        SortOptionRow(
+            label = stringResource(R.string.date_modified),
+            selected = noteOrder is NoteOrder.DateUpdated,
+            orderType = noteOrder.orderType,
+            onClick = {
+                onOrderChange(
+                    if (noteOrder is NoteOrder.DateUpdated) {
+                        noteOrder.copy(noteOrder.orderType.toggle())
+                    } else {
+                        NoteOrder.DateUpdated(noteOrder.orderType)
                     }
                 )
             }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ascending">Ascending</string>
-    <string name="date">Date</string>
+    <string name="date_created">Date created</string>
+    <string name="date_modified">Date modified</string>
     <string name="descending">Descending</string>
     <string name="note_color_default">Default</string>
     <string name="note_color_butter_yellow">Butter Yellow</string>

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorState.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorState.kt
@@ -2,9 +2,11 @@ package com.oussamateyib.thoth.feature.notes.impl.editor
 
 import com.oussamateyib.thoth.core.model.data.NoteColor
 import com.oussamateyib.thoth.feature.notes.impl.R
+import kotlin.time.Instant
 
 data class NoteEditorState(
     val id: Long = 0L,
+    val createdAt: Instant? = null,
     val title: NoteEditorTextFieldState = NoteEditorTextFieldState(hint = R.string.note_title_hint),
     val content: NoteEditorTextFieldState = NoteEditorTextFieldState(hint = R.string.note_content_hint),
     val color: NoteColor = NoteColor.Default,

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/editor/NoteEditorViewModel.kt
@@ -53,6 +53,7 @@ class NoteEditorViewModel @AssistedInject constructor(
                     else -> _state.update {
                         it.copy(
                             id = noteId,
+                            createdAt = note.createdAt,
                             title = NoteEditorTextFieldState(
                                 text = note.title,
                                 hint = R.string.note_title_hint
@@ -117,20 +118,25 @@ class NoteEditorViewModel @AssistedInject constructor(
             delay(300.milliseconds)
 
             with(_state.value) {
+                val now = Clock.System.now()
                 val newId = insertNoteUseCase(
                     Note(
                         id = id,
                         title = title.text,
                         content = content.text,
-                        timestamp = Clock.System.now(),
+                        createdAt = createdAt ?: now,
+                        updatedAt = now,
                         color = color
                     )
                 )
 
-                // Update the state with the new ID if this was a newly created note
+                // Update the state if this was a newly created note
                 if (id == 0L) {
                     _state.update {
-                        it.copy(id = newId)
+                        it.copy(
+                            id = newId,
+                            createdAt = now
+                        )
                     }
                 }
             }

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListState.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListState.kt
@@ -8,7 +8,7 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 data class NoteListState(
     val notes: List<Note> = emptyList(),
     val selectedNoteIds: Set<Long> = emptySet(),
-    val noteOrder: NoteOrder = NoteOrder.Date(OrderType.Descending),
+    val noteOrder: NoteOrder = NoteOrder.DateUpdated(OrderType.Descending),
     val isSortSheetVisible: Boolean = false,
     val isColorPickerVisible: Boolean = false,
     val recentlyDeletedNotes: List<Note> = emptyList(),


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR replaces the single timestamp field on `Note` with two separate fields: `createdAt`, set once on note creation, and `updatedAt`, updated on every save.
