### PR TITLE
Format integers using system locale

### DIFF
--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/util/Localization.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/util/Localization.kt
@@ -1,0 +1,24 @@
+package com.oussamateyib.thoth.core.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import java.text.NumberFormat
+
+@Composable
+fun Int.toLocalizedFormat(): String {
+    val configuration = LocalConfiguration.current
+    val currentLocale = remember(configuration) {
+        // Extract the primary preferred system locale
+        configuration.locales[0]
+    }
+
+    val numberFormatter = remember(currentLocale) {
+        // Initialize the locale-aware integer formatting instance
+        NumberFormat.getIntegerInstance(currentLocale)
+    }
+
+    return remember(this, numberFormatter) {
+        numberFormatter.format(this)
+    }
+}

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.oussamateyib.thoth.core.ui.NoteColorPicker
 import com.oussamateyib.thoth.core.ui.NoteSortSheet
 import com.oussamateyib.thoth.core.ui.noteItems
+import com.oussamateyib.thoth.core.ui.util.toLocalizedFormat
 import com.oussamateyib.thoth.feature.notes.impl.R
 import kotlinx.coroutines.launch
 
@@ -160,7 +161,7 @@ internal fun NoteListScreen(
                     Text(
                         // If in selection mode, show the number of selected notes
                         text = if (state.isSelectionMode) {
-                            "${state.selectedNoteIds.size}"
+                            state.selectedNoteIds.size.toLocalizedFormat()
                         } else {
                             stringResource(R.string.list_screen_top_bar_title)
                         },


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR introduces a reusable function that formats numbers according to the device's system locale.
