### PR TITLE
Add day and night theme variants

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,13 +3,13 @@
     android:installLocation="auto">
 
     <application
+        android:name=".ThothApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:description="@string/app_description"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:name=".ThothApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Thoth">

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="NightAdjusted.Theme.Thoth" parent="android:Theme.Material.NoActionBar" />
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
-    <style name="Theme.Thoth" parent="android:Theme.DeviceDefault.NoActionBar">
-        <item name="android:windowFullscreen">true</item>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="NightAdjusted.Theme.Thoth" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <style name="Theme.Thoth" parent="NightAdjusted.Theme.Thoth">
+        <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
     </style>
 </resources>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR restructures the app's theme to support explicit light and dark variants and disables automatic dark-mode color inversion.
