### PR TITLE
Disable parallel configuration cache and increase JVM heap size

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -3,7 +3,6 @@ kotlin.code.style=official
 # Enable caching between builds
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
 # Enable parallel task execution across subprojects
 org.gradle.parallel=true
 # Show all warnings during builds

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,8 @@ kotlin.code.style=official
 # Enable caching between builds
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
-# JVM settings: 2 GB heap, UTF-8 encoding
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# JVM settings: 4 GB heap, UTF-8 encoding
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # Enable parallel task execution across subprojects
 org.gradle.parallel=true
 # Show all warnings during builds


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR improves build stability and memory overhead by removing an unstable parallel configuration setting and doubling the available JVM heap space.
