### PR TITLE
Remove redundant `--no-build-cache` flag in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
           languages: java-kotlin
 
       - name: Build project
-        run: ./gradlew clean build bundle --no-build-cache
+        run: ./gradlew clean build bundle
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices
