### PR TITLE
Extract lint rules

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -31,8 +31,4 @@ private fun Lint.configure() {
     checkAllWarnings = true
     checkDependencies = true
     warningsAsErrors = true
-    disable += "AndroidGradlePluginVersion"
-    disable += "GradleDependency"
-    disable += "NewerVersionAvailable"
-    disable += "VectorPath"
 }

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="AndroidGradlePluginVersion" severity="ignore" />
+    <issue id="GradleDependency" severity="ignore" />
+    <issue id="NewerVersionAvailable" severity="ignore" />
+    <issue id="VectorPath" severity="ignore" />
+</lint>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR extracts hardcoded lint disables from the convention plugin into a centralized `lint.xml` configuraxtion, allowing for file-specific ignores in the future.
