### PR TITLE
Let users turn dynamic color theming on or off

### DIFF
--- a/app/src/main/kotlin/com/oussamateyib/thoth/MainActivity.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/MainActivity.kt
@@ -34,9 +34,13 @@ class MainActivity : AppCompatActivity() {
 
             if (uiState is MainActivityState.Success) {
                 val appState = rememberThothAppState()
+                val dynamicColor = uiState.shouldUseDynamicColor()
                 val darkTheme = uiState.shouldUseDarkTheme(isSystemInDarkTheme())
 
-                ThothTheme(darkTheme = darkTheme) {
+                ThothTheme(
+                    darkTheme = darkTheme,
+                    dynamicColor = dynamicColor
+                ) {
                     ThothApp(appState)
                 }
             }

--- a/app/src/main/kotlin/com/oussamateyib/thoth/MainActivityState.kt
+++ b/app/src/main/kotlin/com/oussamateyib/thoth/MainActivityState.kt
@@ -8,6 +8,8 @@ sealed interface MainActivityState {
     data class Success(
         val userData: UserData
     ) : MainActivityState {
+        override fun shouldUseDynamicColor() = userData.dynamicColor
+
         override fun shouldUseDarkTheme(isSystemDarkTheme: Boolean) =
             when (userData.darkThemeConfig) {
                 DarkThemeConfig.FOLLOW_SYSTEM -> isSystemDarkTheme
@@ -15,6 +17,8 @@ sealed interface MainActivityState {
                 DarkThemeConfig.DARK -> true
             }
     }
+
+    fun shouldUseDynamicColor() = true
 
     fun shouldUseDarkTheme(isSystemDarkTheme: Boolean) = isSystemDarkTheme
 }

--- a/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/OfflineFirstUserDataRepository.kt
+++ b/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/OfflineFirstUserDataRepository.kt
@@ -9,6 +9,9 @@ class OfflineFirstUserDataRepository @Inject constructor(
 ) : UserDataRepository {
     override val userData = thothPreferencesDataSource.userData
 
+    override suspend fun setDynamicColorPreference(dynamicColor: Boolean) =
+        thothPreferencesDataSource.setDynamicColorPreference(dynamicColor)
+
     override suspend fun setDarkThemeConfig(darkThemeConfig: DarkThemeConfig) =
         thothPreferencesDataSource.setDarkThemeConfig(darkThemeConfig)
 }

--- a/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/UserDataRepository.kt
+++ b/core/data/src/main/kotlin/com/oussamateyib/thoth/core/data/repository/UserDataRepository.kt
@@ -7,5 +7,7 @@ import kotlinx.coroutines.flow.Flow
 interface UserDataRepository {
     val userData: Flow<UserData>
 
+    suspend fun setDynamicColorPreference(dynamicColor: Boolean)
+
     suspend fun setDarkThemeConfig(darkThemeConfig: DarkThemeConfig)
 }

--- a/core/datastore/src/main/kotlin/com/oussamateyib/thoth/core/datastore/ThothPreferencesDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/oussamateyib/thoth/core/datastore/ThothPreferencesDataSource.kt
@@ -2,6 +2,7 @@ package com.oussamateyib.thoth.core.datastore
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -27,6 +28,7 @@ class ThothPreferencesDataSource @Inject constructor(
         }
         .map { preferences ->
             UserData(
+                dynamicColor = preferences[PreferencesKeys.DYNAMIC_COLOR] ?: true,
                 darkThemeConfig = when (preferences[PreferencesKeys.DARK_THEME_CONFIG]) {
                     null -> DarkThemeConfig.FOLLOW_SYSTEM
                     DarkThemeConfig.LIGHT.name -> DarkThemeConfig.LIGHT
@@ -36,6 +38,12 @@ class ThothPreferencesDataSource @Inject constructor(
             )
         }
 
+    suspend fun setDynamicColorPreference(dynamicColor: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.DYNAMIC_COLOR] = dynamicColor
+        }
+    }
+
     suspend fun setDarkThemeConfig(darkThemeConfig: DarkThemeConfig) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.DARK_THEME_CONFIG] = darkThemeConfig.name
@@ -44,5 +52,6 @@ class ThothPreferencesDataSource @Inject constructor(
 }
 
 private object PreferencesKeys {
+    val DYNAMIC_COLOR = booleanPreferencesKey("dynamic_color_preference")
     val DARK_THEME_CONFIG = stringPreferencesKey("dark_theme_config")
 }

--- a/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/SetDynamicColorPreferenceUseCase.kt
+++ b/core/domain/src/main/kotlin/com/oussamateyib/thoth/core/domain/SetDynamicColorPreferenceUseCase.kt
@@ -1,0 +1,11 @@
+package com.oussamateyib.thoth.core.domain
+
+import com.oussamateyib.thoth.core.data.repository.UserDataRepository
+import javax.inject.Inject
+
+class SetDynamicColorPreferenceUseCase @Inject constructor(
+    private val userDataRepository: UserDataRepository
+) {
+    suspend operator fun invoke(dynamicColor: Boolean) =
+        userDataRepository.setDynamicColorPreference(dynamicColor)
+}

--- a/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/UserData.kt
+++ b/core/model/src/main/kotlin/com/oussamateyib/thoth/core/model/data/UserData.kt
@@ -1,5 +1,6 @@
 package com.oussamateyib.thoth.core.model.data
 
 data class UserData(
+    val dynamicColor: Boolean,
     val darkThemeConfig: DarkThemeConfig
 )

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/SettingsSwitch.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/SettingsSwitch.kt
@@ -1,0 +1,48 @@
+package com.oussamateyib.thoth.core.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsSwitchRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) = Row(
+    modifier = modifier
+        .fillMaxWidth()
+        .toggleable(
+            value = checked,
+            enabled = enabled,
+            role = Role.Switch,
+            onValueChange = onCheckedChange
+        )
+        .padding(horizontal = 20.dp, vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically
+) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = Modifier.weight(1f)
+    )
+    Switch(
+        checked = checked,
+        onCheckedChange = null,
+        enabled = enabled,
+        // Clear remaining internal semantics
+        modifier = Modifier.clearAndSetSemantics {}
+    )
+}

--- a/feature/settings/impl/src/main/kotlin/com/oussamateyib/thoth/feature/settings/impl/SettingsEvent.kt
+++ b/feature/settings/impl/src/main/kotlin/com/oussamateyib/thoth/feature/settings/impl/SettingsEvent.kt
@@ -4,6 +4,7 @@ import com.oussamateyib.thoth.core.model.data.DarkThemeConfig
 import com.oussamateyib.thoth.core.model.data.Language
 
 sealed class SettingsEvent {
+    data class SetDynamicColorPreference(val dynamicColor: Boolean) : SettingsEvent()
     data class UpdateDarkThemeConfig(val config: DarkThemeConfig) : SettingsEvent()
     data class UpdateLanguage(val language: Language) : SettingsEvent()
 }

--- a/feature/settings/impl/src/main/kotlin/com/oussamateyib/thoth/feature/settings/impl/SettingsScreen.kt
+++ b/feature/settings/impl/src/main/kotlin/com/oussamateyib/thoth/feature/settings/impl/SettingsScreen.kt
@@ -30,6 +30,7 @@ import com.oussamateyib.thoth.core.model.data.UserData
 import com.oussamateyib.thoth.core.ui.LanguageChooserDialog
 import com.oussamateyib.thoth.core.ui.SettingsItem
 import com.oussamateyib.thoth.core.ui.SettingsSectionTitle
+import com.oussamateyib.thoth.core.ui.SettingsSwitchRow
 import com.oussamateyib.thoth.core.ui.ThemeChooserDialog
 import com.oussamateyib.thoth.core.ui.asLabel
 
@@ -44,6 +45,7 @@ fun SettingsScreen(
 
     SettingsScreen(
         userData = userData,
+        isDynamicColorSupported = viewModel.isDynamicColorSupported,
         currentLanguage = currentLanguage,
         appVersion = viewModel.appVersion,
         onBackClick = onBackClick,
@@ -56,6 +58,7 @@ fun SettingsScreen(
 @Composable
 internal fun SettingsScreen(
     userData: UserData,
+    isDynamicColorSupported: Boolean,
     currentLanguage: Language,
     appVersion: String,
     onBackClick: () -> Unit,
@@ -94,6 +97,12 @@ internal fun SettingsScreen(
                 .verticalScroll(verticalScroll)
         ) {
             SettingsSectionTitle(text = stringResource(R.string.feature_settings_impl_display_options))
+            SettingsSwitchRow(
+                label = stringResource(R.string.feature_settings_impl_dynamic_theming),
+                checked = if (isDynamicColorSupported) userData.dynamicColor else false,
+                enabled = isDynamicColorSupported,
+                onCheckedChange = { onEvent(SettingsEvent.SetDynamicColorPreference(it)) }
+            )
             SettingsItem(
                 label = stringResource(R.string.feature_settings_impl_theme),
                 value = userData.darkThemeConfig.asLabel(),

--- a/feature/settings/impl/src/main/kotlin/com/oussamateyib/thoth/feature/settings/impl/SettingsViewModel.kt
+++ b/feature/settings/impl/src/main/kotlin/com/oussamateyib/thoth/feature/settings/impl/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.oussamateyib.thoth.core.domain.GetUserPreferencesStreamUseCase
 import com.oussamateyib.thoth.core.domain.SetDarkThemeConfigUseCase
+import com.oussamateyib.thoth.core.domain.SetDynamicColorPreferenceUseCase
 import com.oussamateyib.thoth.core.model.data.DarkThemeConfig
 import com.oussamateyib.thoth.core.model.data.Language
 import com.oussamateyib.thoth.core.model.data.UserData
@@ -26,8 +27,11 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     @ApplicationContext context: Context,
     getUserPreferencesStreamUseCase: GetUserPreferencesStreamUseCase,
+    private val setDynamicColorPreferenceUseCase: SetDynamicColorPreferenceUseCase,
     private val setDarkThemeConfigUseCase: SetDarkThemeConfigUseCase
 ) : ViewModel() {
+    val isDynamicColorSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
     val packageInfo: PackageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         context.packageManager.getPackageInfo(
             context.packageName,
@@ -46,11 +50,20 @@ class SettingsViewModel @Inject constructor(
             scope = viewModelScope,
             // Wait 5 seconds before stopping to handle configuration changes smoothly
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = UserData(darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM)
+            initialValue = UserData(
+                dynamicColor = true,
+                darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM
+            )
         )
 
     fun onEvent(event: SettingsEvent) {
         when (event) {
+            is SettingsEvent.SetDynamicColorPreference -> {
+                viewModelScope.launch {
+                    setDynamicColorPreferenceUseCase(event.dynamicColor)
+                }
+            }
+
             is SettingsEvent.UpdateDarkThemeConfig -> {
                 viewModelScope.launch {
                     setDarkThemeConfigUseCase(event.config)

--- a/feature/settings/impl/src/main/res/values-ar/strings.xml
+++ b/feature/settings/impl/src/main/res/values-ar/strings.xml
@@ -4,6 +4,7 @@
     <string name="feature_settings_impl_app_version">إصدار التطبيق</string>
     <string name="feature_settings_impl_back">رجوع</string>
     <string name="feature_settings_impl_display_options">خيارات العرض</string>
+    <string name="feature_settings_impl_dynamic_theming">مظهر ديناميكي</string>
     <string name="feature_settings_impl_theme">المظهر</string>
     <string name="feature_settings_impl_language">اللغة</string>
     <string name="feature_settings_impl_open_source_licenses">تراخيص مفتوحة المصدر</string>

--- a/feature/settings/impl/src/main/res/values/strings.xml
+++ b/feature/settings/impl/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="feature_settings_impl_app_version">App version</string>
     <string name="feature_settings_impl_back">Back</string>
     <string name="feature_settings_impl_display_options">Display options</string>
+    <string name="feature_settings_impl_dynamic_theming">Dynamic theming</string>
     <string name="feature_settings_impl_theme">Theme</string>
     <string name="feature_settings_impl_language">Language</string>
     <string name="feature_settings_impl_open_source_licenses">Open source licenses</string>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a new switch in the settings screen that lets users enable or disable dynamic color theming, which adapts the app's colors to match the user's wallpaper. The choice is saved and restored across app restarts. On devices that don't support this feature, the switch is shown but disabled.
