### PR TITLE
Exclude unnecessary metadata from release APK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,20 @@ android {
     }
 }
 
+androidComponents {
+    onVariants(selector().withBuildType("release")) { variant ->
+        variant.packaging.resources.excludes.add("META-INF/NOTICE.md")
+        variant.packaging.resources.excludes.add("META-INF/**/LICENSE.txt")
+        variant.packaging.resources.excludes.add("META-INF/*.version")
+        // Strip coroutines debugger probes
+        variant.packaging.resources.excludes.add("DebugProbesKt.bin")
+        // Remove build-time verification metadata
+        variant.packaging.resources.excludes.add("META-INF/**/verification.properties")
+        // Strip Kotlin builtins and metadata
+        variant.packaging.resources.excludes.add("kotlin/**")
+    }
+}
+
 dependencies {
     implementation(projects.core.data)
     implementation(projects.core.database)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR excludes unnecessary metadata and resource files (license notices, coroutines debug probes, verification properties, and Kotlin builtins) from the release build packaging to reduce APK size.
