### PR TITLE
Ensure `aboutlibraries` raw resource is not stripped by R8

### DIFF
--- a/app/src/main/res/raw/com_oussamateyib_thoth_keep.xml
+++ b/app/src/main/res/raw/com_oussamateyib_thoth_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a resource keep file for the `aboutlibraries.json` resource. With optimized resource shrinking enabled (the default starting with AGP 9.0), the generated `aboutlibraries.json` file can be removed during the shrinking step since it is only referenced dynamically at runtime and not detected by static analysis.

### Related Issues

- Fixes #156.
