### PR TITLE
Remove deprecated `sarifReport` lint property

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -28,6 +28,5 @@ class AndroidLintConventionPlugin : Plugin<Project> {
 private fun Lint.configure() {
     checkAllWarnings = true
     checkDependencies = true
-    sarifReport = true
     warningsAsErrors = true
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR removes the deprecated `sarifReport` property from the lint configuration. 
AGP now generates SARIF reports automatically by default.
