### PR TITLE
Add testing utilities for notes

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -7,6 +7,8 @@ android {
 }
 
 dependencies {
+    api(projects.core.model)
+
     api(libs.androidx.test.runner)
     implementation(libs.hilt.android.testing)
     api(libs.junit)

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -7,11 +7,12 @@ android {
 }
 
 dependencies {
+    api(projects.core.data)
     api(projects.core.model)
 
     api(libs.androidx.test.runner)
     implementation(libs.hilt.android.testing)
     api(libs.junit)
-    implementation(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.coroutines.core)
     api(libs.kotlinx.coroutines.test)
 }

--- a/core/testing/src/main/kotlin/com/oussamateyib/thoth/core/testing/data/NotesTestData.kt
+++ b/core/testing/src/main/kotlin/com/oussamateyib/thoth/core/testing/data/NotesTestData.kt
@@ -1,0 +1,32 @@
+package com.oussamateyib.thoth.core.testing.data
+
+import com.oussamateyib.thoth.core.model.data.Note
+import com.oussamateyib.thoth.core.model.data.NoteColor
+import kotlin.time.Instant
+
+val notesTestData = listOf(
+    Note(
+        id = 1,
+        title = "Android Architecture",
+        content = "Clean Architecture is great.",
+        createdAt = Instant.fromEpochMilliseconds(1000),
+        updatedAt = Instant.fromEpochMilliseconds(5000),
+        color = NoteColor.SkyBlue,
+    ),
+    Note(
+        id = 2,
+        title = "Better Testing",
+        content = "Unit tests are the foundation.",
+        createdAt = Instant.fromEpochMilliseconds(2000),
+        updatedAt = Instant.fromEpochMilliseconds(4000),
+        color = NoteColor.ButterYellow,
+    ),
+    Note(
+        id = 3,
+        title = "Compose Basics",
+        content = "Declarative UI is the future.",
+        createdAt = Instant.fromEpochMilliseconds(3000),
+        updatedAt = Instant.fromEpochMilliseconds(3000),
+        color = NoteColor.MintGreen,
+    ),
+)

--- a/core/testing/src/main/kotlin/com/oussamateyib/thoth/core/testing/repository/TestNotesRepository.kt
+++ b/core/testing/src/main/kotlin/com/oussamateyib/thoth/core/testing/repository/TestNotesRepository.kt
@@ -1,0 +1,54 @@
+package com.oussamateyib.thoth.core.testing.repository
+
+import com.oussamateyib.thoth.core.data.repository.NotesRepository
+import com.oussamateyib.thoth.core.model.data.Note
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class TestNotesRepository : NotesRepository {
+    private val notesFlow = MutableSharedFlow<List<Note>>(
+        // Cache the latest emitted list for new collectors
+        replay = 1,
+        // Discard the previous list if a new one arrives before it's collected
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private val currentNotes
+        get() = notesFlow.replayCache.firstOrNull() ?: emptyList()
+
+    override fun getNotesStream() = notesFlow
+
+    override suspend fun getNoteById(id: Long) = currentNotes.find { it.id == id }
+
+    override suspend fun insertNote(note: Note): Long {
+        // Generate a new ID if this is a new note
+        val id = if (note.id == 0L) {
+            (currentNotes.maxOfOrNull { it.id } ?: 0L) + 1
+        } else {
+            note.id
+        }
+
+        val updatedNote = note.copy(id = id)
+        val newList = currentNotes.toMutableList().apply {
+            // If the note already exists, update it
+            val index = indexOfFirst { it.id == id }
+            if (index != -1) {
+                set(index, updatedNote)
+            } else {
+                add(updatedNote)
+            }
+        }
+        notesFlow.tryEmit(newList)
+        return id
+    }
+
+    override suspend fun deleteNote(note: Note) {
+        val newList = currentNotes.filterNot { it.id == note.id }
+        notesFlow.tryEmit(newList)
+    }
+
+    // A test-only API to inject notes directly
+    fun sendNotes(notes: List<Note>) {
+        notesFlow.tryEmit(notes)
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR extends the `core:testing` module with a fake notes repository and sample note data to support unit and instrumentation testing across the app.
