### PR TITLE
Add unit tests for ordering utilities

### DIFF
--- a/core/domain/src/test/kotlin/com/oussamateyib/thoth/core/domain/util/NoteOrderTest.kt
+++ b/core/domain/src/test/kotlin/com/oussamateyib/thoth/core/domain/util/NoteOrderTest.kt
@@ -1,0 +1,34 @@
+package com.oussamateyib.thoth.core.domain.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NoteOrderTest {
+    @Test
+    fun titleCopy_returnsTitleWithNewOrderType() {
+        val order = NoteOrder.Title(OrderType.Ascending)
+        val result = order.copy(OrderType.Descending)
+
+        assertTrue(result is NoteOrder.Title)
+        assertEquals(OrderType.Descending, result.orderType)
+    }
+
+    @Test
+    fun dateCreatedCopy_returnsDateCreatedWithNewOrderType() {
+        val order = NoteOrder.DateCreated(OrderType.Ascending)
+        val result = order.copy(OrderType.Descending)
+
+        assertTrue(result is NoteOrder.DateCreated)
+        assertEquals(OrderType.Descending, result.orderType)
+    }
+
+    @Test
+    fun dateUpdatedCopy_returnsDateUpdatedWithNewOrderType() {
+        val order = NoteOrder.DateUpdated(OrderType.Ascending)
+        val result = order.copy(OrderType.Descending)
+
+        assertTrue(result is NoteOrder.DateUpdated)
+        assertEquals(OrderType.Descending, result.orderType)
+    }
+}

--- a/core/domain/src/test/kotlin/com/oussamateyib/thoth/core/domain/util/OrderTypeTest.kt
+++ b/core/domain/src/test/kotlin/com/oussamateyib/thoth/core/domain/util/OrderTypeTest.kt
@@ -1,0 +1,18 @@
+package com.oussamateyib.thoth.core.domain.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OrderTypeTest {
+    @Test
+    fun ascendingToggle_returnsDescending() {
+        val orderType = OrderType.Ascending
+        assertEquals(OrderType.Descending, orderType.toggle())
+    }
+
+    @Test
+    fun descendingToggle_returnsAscending() {
+        val orderType = OrderType.Descending
+        assertEquals(OrderType.Ascending, orderType.toggle())
+    }
+}


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description
This PR adds unit tests for the ordering utilities in the domain layer, covering `NoteOrder` and `OrderType`.