### PR TITLE
Add Robolectric unit tests for `NoteDao`

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/oussamateyib/thoth/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/oussamateyib/thoth/KotlinAndroid.kt
@@ -3,8 +3,10 @@ package com.oussamateyib.thoth
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
 
 internal fun Project.configureKotlinAndroid(
     commonExtension: CommonExtension,
@@ -25,5 +27,12 @@ internal fun Project.configureKotlinAndroid(
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(21))
         }
+    }
+
+    // Allow Robolectric to access internal JVM classes
+    tasks.withType<Test>().configureEach {
+        jvmArgs(
+            "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+        )
     }
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -10,7 +10,13 @@ android {
 
 dependencies {
     api(projects.core.model)
+    testImplementation(projects.core.testing)
 
+    testImplementation(libs.androidx.test.core)
     implementation(libs.javax.inject)
+    testImplementation(libs.junit)
     api(libs.kotlinx.coroutines.core)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.robolectric.annotations)
 }

--- a/core/database/src/test/kotlin/com/oussamateyib/thoth/core/database/ThothDatabaseTest.kt
+++ b/core/database/src/test/kotlin/com/oussamateyib/thoth/core/database/ThothDatabaseTest.kt
@@ -1,0 +1,28 @@
+package com.oussamateyib.thoth.core.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.oussamateyib.thoth.core.database.dao.NoteDao
+import org.junit.After
+import org.junit.Before
+
+abstract class ThothDatabaseTest {
+    private lateinit var db: ThothDatabase
+    protected lateinit var noteDao: NoteDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(
+            context,
+            ThothDatabase::class.java,
+        ).build()
+        noteDao = db.noteDao()
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+}

--- a/core/database/src/test/kotlin/com/oussamateyib/thoth/core/database/dao/NoteDaoTest.kt
+++ b/core/database/src/test/kotlin/com/oussamateyib/thoth/core/database/dao/NoteDaoTest.kt
@@ -1,0 +1,57 @@
+package com.oussamateyib.thoth.core.database.dao
+
+import com.oussamateyib.thoth.core.database.ThothDatabaseTest
+import com.oussamateyib.thoth.core.database.model.asEntity
+import com.oussamateyib.thoth.core.testing.data.notesTestData
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [37])
+class NoteDaoTest : ThothDatabaseTest() {
+    @Test
+    fun insertNote_retrievesNoteById() = runTest {
+        val note = notesTestData.first().asEntity()
+        noteDao.insertNote(note)
+
+        val retrievedNote = noteDao.getNoteById(note.id)
+        assertEquals(note, retrievedNote)
+    }
+
+    @Test
+    fun getNotes_emitsAllNotes() = runTest {
+        val entities = notesTestData.map { it.asEntity() }
+        entities.forEach { noteDao.insertNote(it) }
+
+        val notes = noteDao.getNotes().first()
+        assertEquals(entities.size, notes.size)
+        assertEquals(entities.sortedBy { it.id }, notes.sortedBy { it.id })
+    }
+
+    @Test
+    fun insertNote_replacesOnConflict() = runTest {
+        val note1 = notesTestData.first().asEntity().copy(title = "Original Title")
+        noteDao.insertNote(note1)
+
+        val note2 = note1.copy(title = "Updated Title")
+        noteDao.insertNote(note2)
+
+        val retrievedNote = noteDao.getNoteById(note1.id)
+        assertEquals("Updated Title", retrievedNote?.title)
+    }
+
+    @Test
+    fun deleteNote_removesNoteFromDatabase() = runTest {
+        val note = notesTestData.first().asEntity()
+        noteDao.insertNote(note)
+        noteDao.deleteNote(note)
+
+        val retrievedNote = noteDao.getNoteById(note.id)
+        assertEquals(null, retrievedNote)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ kotlin = "2.4.10"
 ksp = "2.3.10"
 lifecycle = "2.11.0"
 navigation3 = "1.1.4"
+robolectric = "4.17-beta-2"
 room = "2.8.4"
 serialization = "1.11.0"
 splashscreen = "1.2.0"
@@ -64,6 +65,7 @@ androidx-room-common = { group = "androidx.room", name = "room-common", version.
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime-android", version.ref = "room" }
 androidx-sqlite = { group = "androidx.sqlite", name = "sqlite", version.ref = "sqlite" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "test" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "test" }
 dagger = { group = "com.google.dagger", name = "dagger", version.ref = "hilt" }
 dagger-hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
@@ -77,6 +79,8 @@ kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "serialization" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+robolectric-annotations = { group = "org.robolectric", name = "annotations", version.ref = "robolectric" }
 
 # Dependencies of the included build-logic
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle-api", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds Robolectric-based unit tests for `NoteDao`, covering insert, retrieval, conflict replacement, and delete operations against an in-memory Room database.