### PR TITLE
Refactor Dependency Analysis Gradle Plugin setup

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -14,7 +14,7 @@ java {
 
 dependencies {
     compileOnly(libs.android.gradle.plugin)
-    compileOnly(libs.dependency.analysis.gradle.plugin)
+    implementation(libs.dependency.analysis.gradle.plugin)
     compileOnly(libs.ksp.gradle.plugin)
     compileOnly(libs.room.gradle.plugin)
 }

--- a/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
@@ -18,6 +18,9 @@ class DependencyAnalysisConventionPlugin : Plugin<Project> {
                             }
                         }
                     }
+                    reporting {
+                        printBuildHealth(true)
+                    }
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
@@ -13,7 +13,7 @@ class DependencyAnalysisConventionPlugin : Plugin<Project> {
                 extensions.configure<DependencyAnalysisExtension> {
                     issues {
                         all {
-                            onUnusedDependencies {
+                            onAny {
                                 severity("fail")
                             }
                         }

--- a/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
@@ -1,4 +1,4 @@
-import com.autonomousapps.DependencyAnalysisSubExtension
+import com.autonomousapps.DependencyAnalysisExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -9,9 +9,15 @@ class DependencyAnalysisConventionPlugin : Plugin<Project> {
         with(target) {
             apply(plugin = "com.autonomousapps.dependency-analysis")
 
-            extensions.configure<DependencyAnalysisSubExtension> {
-                issues {
-                    onUnusedDependencies { severity("fail") }
+            if (this == rootProject) {
+                extensions.configure<DependencyAnalysisExtension> {
+                    issues {
+                        all {
+                            onUnusedDependencies {
+                                severity("fail")
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DependencyAnalysisConventionPlugin.kt
@@ -21,6 +21,7 @@ class DependencyAnalysisConventionPlugin : Plugin<Project> {
                     reporting {
                         printBuildHealth(true)
                     }
+                    useTypesafeProjectAccessors(true)
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,12 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose) apply false
-    alias(libs.plugins.thoth.dependency.analysis)
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.room) apply false
+    alias(libs.plugins.thoth.dependency.analysis)
 }
 
 buildscript {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose) apply false
-    alias(libs.plugins.dependency.analysis)
+    alias(libs.plugins.thoth.dependency.analysis)
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR migrates the root project's dependency analysis setup to use the convention plugin, and reconfigures how and where it's applied.

### Changes

- Switched the `dependency.analysis` plugin alias to `thoth.dependency.analysis`.
- Widened issue checks to fail on any issue type  instead of only unused dependencies.
- Enabled build health reporting to be printed to the console.
- Enabled typesafe project accessors.
- Changed `dependency.analysis.gradle.plugin` from `compileOnly` to `implementation` in the convention plugin to make it available to the root build script as well.