### PR TITLE
Add instrumented tests for `NoteDao`

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -10,12 +10,16 @@ android {
 
 dependencies {
     api(projects.core.model)
+    androidTestImplementation(projects.core.testing)
     testImplementation(projects.core.testing)
 
+    androidTestImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.test.core)
     implementation(libs.javax.inject)
+    androidTestImplementation(libs.junit)
     testImplementation(libs.junit)
     api(libs.kotlinx.coroutines.core)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     testImplementation(libs.robolectric.annotations)

--- a/core/database/src/androidTest/kotlin/com/oussamateyib/thoth/core/database/ThothDatabaseTest.kt
+++ b/core/database/src/androidTest/kotlin/com/oussamateyib/thoth/core/database/ThothDatabaseTest.kt
@@ -1,0 +1,28 @@
+package com.oussamateyib.thoth.core.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.oussamateyib.thoth.core.database.dao.NoteDao
+import org.junit.After
+import org.junit.Before
+
+abstract class ThothDatabaseTest {
+    private lateinit var db: ThothDatabase
+    protected lateinit var noteDao: NoteDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(
+            context,
+            ThothDatabase::class.java,
+        ).build()
+        noteDao = db.noteDao()
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+}

--- a/core/database/src/androidTest/kotlin/com/oussamateyib/thoth/core/database/dao/NoteDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/oussamateyib/thoth/core/database/dao/NoteDaoTest.kt
@@ -1,0 +1,52 @@
+package com.oussamateyib.thoth.core.database.dao
+
+import com.oussamateyib.thoth.core.database.ThothDatabaseTest
+import com.oussamateyib.thoth.core.database.model.asEntity
+import com.oussamateyib.thoth.core.testing.data.notesTestData
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NoteDaoTest : ThothDatabaseTest() {
+    @Test
+    fun insertNote_retrievesNoteById() = runTest {
+        val note = notesTestData.first().asEntity()
+        noteDao.insertNote(note)
+
+        val retrievedNote = noteDao.getNoteById(note.id)
+        assertEquals(note, retrievedNote)
+    }
+
+    @Test
+    fun getNotes_emitsAllNotes() = runTest {
+        val entities = notesTestData.map { it.asEntity() }
+        entities.forEach { noteDao.insertNote(it) }
+
+        val notes = noteDao.getNotes().first()
+        assertEquals(entities.size, notes.size)
+        assertEquals(entities.sortedBy { it.id }, notes.sortedBy { it.id })
+    }
+
+    @Test
+    fun insertNote_replacesOnConflict() = runTest {
+        val note1 = notesTestData.first().asEntity().copy(title = "Original Title")
+        noteDao.insertNote(note1)
+
+        val note2 = note1.copy(title = "Updated Title")
+        noteDao.insertNote(note2)
+
+        val retrievedNote = noteDao.getNoteById(note1.id)
+        assertEquals("Updated Title", retrievedNote?.title)
+    }
+
+    @Test
+    fun deleteNote_removesNoteFromDatabase() = runTest {
+        val note = notesTestData.first().asEntity()
+        noteDao.insertNote(note)
+        noteDao.deleteNote(note)
+
+        val retrievedNote = noteDao.getNoteById(note.id)
+        assertEquals(null, retrievedNote)
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds Android instrumented tests for the `core/database` module, covering `NoteDao` operations against a real in-memory Room database. It also introduces a shared `ThothDatabaseTest` base class to handle database setup and teardown for future DAO tests.
