### PR TITLE
Drop legacy run configurations exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ local.properties
 !.idea/kotlinc.xml
 !.idea/markdown.xml
 !.idea/misc.xml
-!.idea/runConfigurations/
 !.idea/vcs.xml
 *.iml
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR removes the tracking exception for the older run configuration folder. Project run configurations now use the standard `.run/` root directory instead.
