### PR TITLE
Remove unnecessary missing annotation warning suppression

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,6 @@ android {
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
             )
 
             // Remove unused resources

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,2 +1,0 @@
-# Suppress missing class warning for Hilt's internal compile-time annotation
--dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR removes the ProGuard rule suppressing R8's missing class warning for Hilt's internal compile-time annotation, since it is no longer needed as of Hilt 2.60.1.
