### PR TITLE
Migrate `ListItem` to use trailing `content` lambda instead of `headlineContent`

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteSortSheet.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteSortSheet.kt
@@ -93,7 +93,6 @@ internal fun SortOptionRow(
     orderType: OrderType,
     onClick: () -> Unit,
 ) = ListItem(
-    headlineContent = { Text(label) },
     leadingContent = {
         Box(
             modifier = Modifier.size(24.dp),
@@ -117,4 +116,6 @@ internal fun SortOptionRow(
         .padding(horizontal = 4.dp)
         .clip(CircleShape)
         .clickable(onClick = onClick),
-)
+) {
+    Text(label)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "annotation" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom-alpha", version.ref = "composeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }


### PR DESCRIPTION
### Prerequisites

- [x] have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Related Issues

- Fixes #194.
