### PR TITLE
Refactor `NoteColorPicker`

### DIFF
--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteColorPicker.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteColorPicker.kt
@@ -2,16 +2,17 @@ package com.oussamateyib.thoth.core.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalGridApi
 import androidx.compose.foundation.layout.Grid
 import androidx.compose.foundation.layout.GridTrackSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -37,14 +38,15 @@ fun NoteColorPicker(
     selectedColor: NoteColor? = null,
     layout: PaletteLayout = PaletteLayout.Grid,
 ) = when (layout) {
-    PaletteLayout.Row -> LazyRow(
+    PaletteLayout.Row -> Row(
         modifier = modifier
             .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
             .padding(8.dp),
         horizontalArrangement = Arrangement.spacedBy(5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        items(NoteColor.entries) {
+        NoteColor.entries.forEach {
             ColorSwatch(it, it == selectedColor, { onColorChange(it) })
         }
     }

--- a/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteColorPicker.kt
+++ b/core/ui/src/main/kotlin/com/oussamateyib/thoth/core/ui/NoteColorPicker.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalGridApi
+import androidx.compose.foundation.layout.Grid
+import androidx.compose.foundation.layout.GridTrackSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
@@ -29,6 +29,7 @@ import com.oussamateyib.thoth.core.model.data.NoteColor
 import com.oussamateyib.thoth.core.ui.util.PaletteLayout
 import com.oussamateyib.thoth.core.designsystem.R as DesignR
 
+@OptIn(ExperimentalGridApi::class)
 @Composable
 fun NoteColorPicker(
     onColorChange: (NoteColor) -> Unit,
@@ -48,13 +49,24 @@ fun NoteColorPicker(
         }
     }
 
-    PaletteLayout.Grid -> LazyVerticalGrid(
-        columns = GridCells.Fixed(4),
-        modifier = modifier.padding(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(5.dp),
-        verticalArrangement = Arrangement.spacedBy(5.dp),
+    PaletteLayout.Grid -> Grid(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        config = {
+            val cols = if (constraints.maxWidth.toDp() < 600.dp) 4 else 6
+            val rows = (NoteColor.entries.size + cols - 1) / cols
+
+            repeat(cols) {
+                column(1.fr)
+            }
+            repeat(rows) {
+                row(GridTrackSize.Auto)
+            }
+            gap(5.dp)
+        },
     ) {
-        items(NoteColor.entries) {
+        NoteColor.entries.forEach {
             ColorSwatch(it, it == selectedColor, { onColorChange(it) })
         }
     }

--- a/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
+++ b/feature/notes/impl/src/main/kotlin/com/oussamateyib/thoth/feature/notes/impl/list/NoteListScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.BasicAlertDialog
@@ -118,7 +117,6 @@ internal fun NoteListScreen(
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,
                 tonalElevation = AlertDialogDefaults.TonalElevation,
-                modifier = Modifier.width(280.dp),
             ) {
                 NoteColorPicker(
                     selectedColor = state.commonSelectedColor,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR migrates `NoteColorPicker` from the lazy layout APIs (`LazyVerticalGrid`, `LazyRow`) to the experimental `Grid` API and a scrollable `Row`, enabling a responsive column count for the grid layout and removing the fixed-width constraint on the color picker dialog.