### PR TITLE
Enable strict AGP 10.0 compatibility flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Enforce built-in Kotlin support
+android.builtInKotlin=true
+# Enforce modern DSL exclusively
+android.newDsl=true
 # Smaller, faster R classes (no transitive refs)
 android.nonTransitiveRClass=true
 # Kotlin code style


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR enables two strict Android Gradle Plugin (AGP) 10.0 forward-compatibility flags in `gradle.properties` to validate build behavior ahead of the AGP 10.0 release.

### Changes

- Enabled `android.builtInKotlin` to enforce built-in Kotlin support without the optional opt-out.
- Enabled `android.newDsl` to enforce exclusive use of the modern DSL and Variant API interfaces.
